### PR TITLE
chore(vscode): update color theme to `Monokai Pro`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "workbench.colorTheme": "Dracula Theme",
+  "workbench.colorTheme": "Monokai Pro (Filter Spectrum)",
   "editor.tabSize": 2,
   "editor.fontFamily": "'CascaydiaCove Nerd Font Mono', Cascadia Code Nerd Font, Cascadia Code, D2Coding, Consolas, Fira Code, monospace",
   "terminal.integrated.fontFamily": "Hack Nerd Font Mono, Cascadia Code, monospace",


### PR DESCRIPTION
## Summary
- Update VS Code color theme from `Dracula Theme` to `Monokai Pro (Filter Spectrum)`

## Technical Details
- Modified `settings.json`: Changed `workbench.colorTheme` setting value

## Testing
- Open the project in VS Code and verify the `Monokai Pro (Filter Spectrum)` theme is applied

## Breaking Changes
- None