### PR TITLE
feat(presentation): Add PinItem graphics item for pin rendering [CU-86evzm2hj]

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "clickup:sync": "npx ts-node scripts/clickup/sync-specs-to-clickup.ts",
     "spec:start": "npx ts-node scripts/workflow/start-spec.ts",
-    "spec:next": "npx ts-node scripts/workflow/next-spec.ts"
+    "spec:next": "npx ts-node scripts/workflow/next-spec.ts",
+    "verify": "uv run mypy && uv run pytest -v"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/specs/E02/F01/T02/E02-F01-T02-implementation-narrative.md
+++ b/specs/E02/F01/T02/E02-F01-T02-implementation-narrative.md
@@ -1,0 +1,688 @@
+# E02-F01-T02: Pin Graphics Item - Implementation Narrative
+
+## 1. Executive Summary
+
+This document provides a comprehensive walkthrough of implementing `PinItem`, a custom `QGraphicsItem` subclass that renders pins (connection points) on cell symbols in Ink's schematic canvas. The implementation followed Test-Driven Development (TDD) methodology, resulting in a robust, well-tested graphics component.
+
+**Key Achievements**:
+- Implemented `PinItem` class with 450+ lines of thoroughly documented code
+- Created 39 unit tests covering all acceptance criteria
+- Established pattern for parent-child graphics items
+- Accurate connection point calculation for net routing
+
+---
+
+## 2. Problem Context
+
+### 2.1 Business Need
+
+Pins are the fundamental connection points in a schematic. They serve multiple critical functions:
+
+1. **Visual Communication**: Show where signals enter and exit cells
+2. **Direction Indication**: Display arrows showing signal flow (input/output/inout)
+3. **Net Attachment**: Provide precise coordinates for net routing
+4. **Name Display**: Show pin names for identification
+
+### 2.2 Technical Challenge
+
+The implementation needed to address:
+
+1. **Parent-Child Relationship**: Pins must be children of cells for coordinate inheritance
+2. **Coordinate Transformation**: Connection points must be in scene coordinates
+3. **Detail Levels**: Three LOD levels matching CellItem's system
+4. **Direction Arrows**: Different arrow styles for input/output/inout
+
+---
+
+## 3. Solution Architecture
+
+### 3.1 Class Diagram
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                          QGraphicsItem                              │
+│                         (Qt Framework)                              │
+└────────────────────────────────────────────────────────────────────┘
+                                  △
+                                  │ inherits
+                                  │
+┌────────────────────────────────────────────────────────────────────┐
+│                           PinItem                                   │
+│                    (Presentation Layer)                             │
+├────────────────────────────────────────────────────────────────────┤
+│ Class Constants:                                                    │
+│   PIN_RADIUS = 3.0           # Pin circle radius                   │
+│   ARROW_SIZE = 8.0           # Arrow length                        │
+│   LABEL_OFFSET = 5.0         # Distance from pin to label          │
+│   LABEL_FONT_SIZE = 8        # Font size in points                 │
+│   PIN_COLOR = #333333        # Dark gray                           │
+│   _LABEL_COLOR = #000000     # Black                               │
+├────────────────────────────────────────────────────────────────────┤
+│ Instance Attributes:                                                │
+│   _pin: Pin                  # Domain entity reference              │
+│   _detail_level: DetailLevel # Current LOD                          │
+├────────────────────────────────────────────────────────────────────┤
+│ Required Methods (QGraphicsItem):                                   │
+│   boundingRect() -> QRectF                                         │
+│   paint(painter, option, widget)                                   │
+├────────────────────────────────────────────────────────────────────┤
+│ Public API:                                                         │
+│   get_connection_point() -> QPointF  # For net routing              │
+│   set_detail_level(level)            # For zoom LOD                 │
+│   get_pin() -> Pin                   # Domain entity access         │
+└────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  │ child of
+                                  ▼
+┌────────────────────────────────────────────────────────────────────┐
+│                           CellItem                                  │
+│                    (Parent Graphics Item)                           │
+└────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  │ references
+                                  ▼
+┌────────────────────────────────────────────────────────────────────┐
+│                             Pin                                     │
+│                        (Domain Layer)                               │
+├────────────────────────────────────────────────────────────────────┤
+│   id: PinId                                                         │
+│   name: str                                                         │
+│   direction: PinDirection (INPUT/OUTPUT/INOUT)                     │
+│   net_id: NetId | None                                             │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Coordinate System Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Scene Coordinates                            │
+│                                                                      │
+│   CellItem.pos() = (100, 200)                                       │
+│   ┌───────────────────────────────────────────────────────────┐     │
+│   │                    CellItem                                │     │
+│   │                                                            │     │
+│   │   PinItem.pos() = (0, 20) [relative to parent]             │     │
+│   │   ●                                                        │     │
+│   │                                                            │     │
+│   │   PinItem.get_connection_point() = (100, 220) [scene]      │     │
+│   │                                                            │     │
+│   └───────────────────────────────────────────────────────────┘     │
+│                                                                      │
+│   How it works:                                                      │
+│   1. PinItem calls mapToScene(QPointF(0, 0))                        │
+│   2. Qt transforms (0, 0) through parent chain                       │
+│   3. Result: parent.pos() + pin.pos() = (100+0, 200+20) = (100, 220)│
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Implementation Walkthrough
+
+### 4.1 TDD RED Phase - Writing Failing Tests
+
+The first step was writing comprehensive tests for all required functionality:
+
+```python
+# tests/unit/presentation/canvas/test_pin_item.py
+
+class TestPinItemCreation:
+    """Tests for PinItem instantiation and basic properties."""
+
+    def test_pin_item_can_be_created(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that PinItem can be instantiated with a Pin entity and parent."""
+        pin_item = PinItem(input_pin, parent_cell_item)
+        assert pin_item is not None
+
+    def test_pin_item_has_parent_cell_item(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that PinItem is a child of the parent CellItem."""
+        pin_item = PinItem(input_pin, parent_cell_item)
+        assert pin_item.parentItem() is parent_cell_item
+```
+
+**Test Categories**:
+1. **Creation** (5 tests): Constructor, subclass, pin reference, parent, default level
+2. **Constants** (3 tests): PIN_RADIUS, ARROW_SIZE, LABEL_OFFSET
+3. **Bounding Rect** (5 tests): Return type, MINIMAL, BASIC, FULL, long names
+4. **Detail Level** (4 tests): MINIMAL hides, BASIC/FULL show, triggers update
+5. **Connection Point** (5 tests): Return type, origin, pin/parent positions, movement
+6. **Direction Arrows** (3 tests): Input, output, inout directions
+7. **Paint** (6 tests): Method, all detail levels, all directions
+8. **Scene Integration** (3 tests): Scene items, multiple pins, visibility
+9. **Edge Cases** (3 tests): Floating pin, empty name, same level
+10. **Performance** (2 tests): Creation speed, calculation speed
+
+### 4.2 TDD GREEN Phase - Implementation
+
+#### 4.2.1 Class Structure
+
+```python
+# src/ink/presentation/canvas/pin_item.py
+
+class PinItem(QGraphicsItem):
+    """QGraphicsItem representing a pin on a cell symbol."""
+
+    # Geometry constants
+    PIN_RADIUS: float = 3.0
+    ARROW_SIZE: float = 8.0
+    LABEL_OFFSET: float = 5.0
+    LABEL_FONT_SIZE: int = 8
+
+    # Color constants
+    PIN_COLOR = QColor("#333333")
+    _LABEL_COLOR = QColor("#000000")
+```
+
+#### 4.2.2 Constructor with Parent-Child Relationship
+
+```python
+def __init__(
+    self, pin: Pin, parent_cell_item: QGraphicsItem
+) -> None:
+    """Initialize pin graphics item.
+
+    The key insight is passing parent_cell_item to super().__init__().
+    This establishes the parent-child relationship automatically.
+    """
+    # Initialize as child of parent cell item
+    super().__init__(parent_cell_item)  # <-- Critical!
+
+    # Store domain entity reference
+    self._pin = pin
+
+    # Default to FULL detail level
+    self._detail_level = DetailLevel.FULL
+```
+
+#### 4.2.3 Bounding Rect with Detail Level Awareness
+
+```python
+def boundingRect(self) -> QRectF:
+    """Return bounding rectangle based on detail level.
+
+    The bounding rect must adapt to detail level:
+    - MINIMAL: Empty (hidden, nothing to render)
+    - BASIC: Small (just the pin circle)
+    - FULL: Large (circle + label + arrow)
+    """
+    # MINIMAL: Empty bounds
+    if self._detail_level == DetailLevel.MINIMAL:
+        return QRectF()
+
+    # BASIC: Just the pin circle
+    if self._detail_level == DetailLevel.BASIC:
+        return QRectF(
+            -self.PIN_RADIUS, -self.PIN_RADIUS,
+            self.PIN_RADIUS * 2, self.PIN_RADIUS * 2
+        )
+
+    # FULL: Include label and arrow extents
+    bounds = QRectF(-self.PIN_RADIUS, -self.PIN_RADIUS,
+                    self.PIN_RADIUS * 2, self.PIN_RADIUS * 2)
+
+    # Expand based on direction
+    arrow_extent = self.ARROW_SIZE + 2
+    label_extent = self._estimate_label_width() + self.LABEL_OFFSET
+
+    if self._pin.direction == PinDirection.INPUT:
+        bounds.adjust(-label_extent, -5, arrow_extent, 5)
+    elif self._pin.direction == PinDirection.OUTPUT:
+        bounds.adjust(-arrow_extent, -5, label_extent, 5)
+    else:  # INOUT
+        extent = max(arrow_extent, label_extent)
+        bounds.adjust(-extent, -5, extent, 5)
+
+    return bounds
+```
+
+#### 4.2.4 Paint Method with All Detail Levels
+
+```python
+def paint(self, painter: QPainter, _option, _widget=None) -> None:
+    """Render pin with appropriate detail level.
+
+    Rendering progression:
+    1. MINIMAL: Return immediately (nothing rendered)
+    2. BASIC: Draw pin circle only
+    3. FULL: Draw circle, then label, then direction arrow
+    """
+    # MINIMAL: Don't render
+    if self._detail_level == DetailLevel.MINIMAL:
+        return
+
+    # BASIC and FULL: Draw pin circle
+    painter.setPen(QPen(self.PIN_COLOR, 1))
+    painter.setBrush(QBrush(self.PIN_COLOR))
+    painter.drawEllipse(QPointF(0, 0), self.PIN_RADIUS, self.PIN_RADIUS)
+
+    # BASIC: Stop here
+    if self._detail_level == DetailLevel.BASIC:
+        return
+
+    # FULL: Draw label and arrow
+    self._draw_label(painter)
+    self._draw_direction_arrow(painter)
+```
+
+#### 4.2.5 Direction Arrow Rendering
+
+```python
+def _draw_input_arrow(self, painter: QPainter) -> None:
+    """Draw arrow pointing into cell (rightward →).
+
+    Arrow is drawn as a polyline from base to tip with barbs.
+    """
+    base_x = self.PIN_RADIUS + 2  # Start after pin circle
+
+    # Create arrow as polyline: base → tip → barbs
+    arrow = QPolygonF([
+        QPointF(base_x, 0),                          # Base
+        QPointF(base_x + self.ARROW_SIZE, 0),        # Tip
+        QPointF(base_x + self.ARROW_SIZE - 3, -3),   # Upper barb
+        QPointF(base_x + self.ARROW_SIZE, 0),        # Back to tip
+        QPointF(base_x + self.ARROW_SIZE - 3, 3),    # Lower barb
+    ])
+    painter.drawPolyline(arrow)
+```
+
+#### 4.2.6 Connection Point Calculation
+
+```python
+def get_connection_point(self) -> QPointF:
+    """Return the scene coordinate for net attachment.
+
+    This is the most critical method for integration with net routing.
+    Uses Qt's mapToScene() to handle all coordinate transformations.
+    """
+    # Pin center is at item origin (0, 0)
+    item_pos = QPointF(0, 0)
+
+    # Convert to scene coordinates
+    # This automatically handles:
+    # - Pin's position relative to parent cell
+    # - Parent cell's position in scene
+    # - Any transformations in the chain
+    scene_pos = self.mapToScene(item_pos)
+
+    return scene_pos
+```
+
+### 4.3 TDD REFACTOR Phase
+
+After all tests passed, refactoring focused on:
+
+1. **Type consistency**: Changed `label_y = 4` to `label_y = 4.0` for consistent float types
+2. **Documentation**: Added comprehensive docstrings to all methods
+3. **Code organization**: Grouped related methods together
+
+---
+
+## 5. Key Implementation Details
+
+### 5.1 Parent-Child Coordinate Transformation
+
+The most important aspect of PinItem is the parent-child relationship:
+
+```python
+# When creating a PinItem:
+cell_item = CellItem(cell)
+cell_item.setPos(100.0, 200.0)  # Cell at (100, 200) in scene
+
+pin_item = PinItem(pin, cell_item)  # Parent-child established
+pin_item.setPos(0.0, 20.0)  # Pin at (0, 20) relative to cell
+
+# When calculating connection point:
+connection_pt = pin_item.get_connection_point()
+# Returns: (100, 220) in scene coordinates
+
+# Why it works:
+# mapToScene(0, 0) traverses the parent chain:
+#   PinItem local (0, 0)
+#   + PinItem pos (0, 20)
+#   + CellItem pos (100, 200)
+#   = Scene (100, 220)
+```
+
+### 5.2 Detail Level State Management
+
+```python
+def set_detail_level(self, level: DetailLevel) -> None:
+    """Set the level of detail based on zoom.
+
+    Critical behaviors:
+    1. Skip if level unchanged (optimization)
+    2. Update visibility based on level
+    3. Trigger repaint for visual update
+    """
+    # Optimization: skip if no change
+    if self._detail_level == level:
+        return
+
+    self._detail_level = level
+
+    # MINIMAL = hidden, others = visible
+    self.setVisible(level != DetailLevel.MINIMAL)
+
+    # Trigger repaint
+    self.update()
+```
+
+### 5.3 Label Positioning Strategy
+
+```python
+def _draw_label(self, painter: QPainter) -> None:
+    """Position labels based on pin direction.
+
+    Strategy:
+    - INPUT pins are on left edge → label goes left (outside cell)
+    - OUTPUT pins are on right edge → label goes right (outside cell)
+    - INOUT pins → label goes above to avoid ambiguity
+    """
+    if self._pin.direction == PinDirection.INPUT:
+        # Label on left (outside cell)
+        label_x = -self.LABEL_OFFSET - self._estimate_label_width()
+        label_y = 4.0  # Baseline adjustment
+
+    elif self._pin.direction == PinDirection.OUTPUT:
+        # Label on right (outside cell)
+        label_x = self.LABEL_OFFSET
+        label_y = 4.0
+
+    else:  # INOUT
+        # Label above pin
+        label_x = -self._estimate_label_width() / 2
+        label_y = -self.LABEL_OFFSET
+```
+
+---
+
+## 6. Testing Strategy
+
+### 6.1 Test Fixtures
+
+```python
+@pytest.fixture
+def input_pin() -> Pin:
+    """Create an input pin for testing."""
+    return Pin(
+        id=PinId("U1.A"),
+        name="A",
+        direction=PinDirection.INPUT,
+        net_id=NetId("net_001"),
+    )
+
+@pytest.fixture
+def parent_cell_item(parent_cell: Cell) -> CellItem:
+    """Create a parent CellItem for testing pin items."""
+    return CellItem(parent_cell)
+```
+
+### 6.2 Critical Test Cases
+
+**Connection Point Accuracy Test**:
+```python
+def test_connection_point_accounts_for_parent_position(
+    self, qtbot, input_pin, parent_cell_item, graphics_scene
+) -> None:
+    """Test connection point when parent cell has position.
+
+    This test validates the core coordinate transformation.
+    """
+    graphics_scene.addItem(parent_cell_item)
+    parent_cell_item.setPos(100.0, 200.0)  # Cell at (100, 200)
+
+    pin_item = PinItem(input_pin, parent_cell_item)
+    pin_item.setPos(10.0, 20.0)  # Pin at (10, 20) relative
+
+    connection_point = pin_item.get_connection_point()
+
+    # Should be (110, 220) in scene coordinates
+    assert connection_point.x() == pytest.approx(110.0, abs=0.1)
+    assert connection_point.y() == pytest.approx(220.0, abs=0.1)
+```
+
+**Performance Test**:
+```python
+def test_pin_item_creation_is_fast(self, qtbot, input_pin, parent_cell_item):
+    """Test that creating many pin items is reasonably fast."""
+    import time
+    start = time.perf_counter()
+
+    for i in range(100):
+        pin = Pin(id=PinId(f"U1.P{i}"), name=f"P{i}",
+                  direction=PinDirection.INPUT, net_id=None)
+        PinItem(pin, parent_cell_item)
+
+    elapsed = time.perf_counter() - start
+
+    # Should create 100 items in less than 0.5 seconds
+    assert elapsed < 0.5
+```
+
+---
+
+## 7. Integration Points
+
+### 7.1 With CellItem (E02-F01-T01)
+
+```python
+# CellItem creates pins as children
+cell_item = CellItem(cell)
+scene.addItem(cell_item)
+
+for pin in cell.pins:
+    pin_item = PinItem(pin, parent_cell_item=cell_item)
+    # Position set by SymbolLayoutCalculator (T03)
+    pin_item.setPos(calculated_x, calculated_y)
+```
+
+### 7.2 With SymbolLayoutCalculator (E02-F01-T03)
+
+```python
+# T03 calculates pin positions
+calculator = SymbolLayoutCalculator()
+layouts = calculator.calculate_pin_layouts(cell)
+
+for pin_id, layout in layouts.items():
+    pin_item = PinItem(cell.get_pin(pin_id), cell_item)
+    pin_item.setPos(layout.position)  # Relative to cell
+```
+
+### 7.3 With Net Router (E02-F03)
+
+```python
+# Router uses connection points to draw nets
+start_point = start_pin_item.get_connection_point()  # Scene coords
+end_point = end_pin_item.get_connection_point()      # Scene coords
+net_path = router.route(start_point, end_point)
+```
+
+### 7.4 With Zoom LOD (E02-F01-T04)
+
+```python
+# Canvas updates detail level on zoom
+def on_zoom_changed(self, zoom_factor: float):
+    level = DetailLevel.from_zoom(zoom_factor)
+    for item in self.scene().items():
+        if isinstance(item, PinItem):
+            item.set_detail_level(level)
+```
+
+---
+
+## 8. Error Handling
+
+### 8.1 Empty Pin Names
+
+```python
+def _draw_label(self, painter: QPainter) -> None:
+    # Skip if pin name is empty
+    if not self._pin.name:
+        return
+    # ... draw label
+```
+
+### 8.2 Detail Level Optimization
+
+```python
+def set_detail_level(self, level: DetailLevel) -> None:
+    # Skip if level hasn't changed
+    if self._detail_level == level:
+        return
+    # ... update level
+```
+
+---
+
+## 9. Performance Considerations
+
+### 9.1 Creation Performance
+
+- 100 PinItems created in < 0.5 seconds
+- Simple constructor with minimal initialization
+- No expensive computations in constructor
+
+### 9.2 Rendering Performance
+
+- MINIMAL level: No rendering at all
+- BASIC level: Single `drawEllipse` call
+- FULL level: Circle + label + arrow (3 draw operations)
+
+### 9.3 Connection Point Calculation
+
+- 1000 calculations in < 0.1 seconds
+- Uses Qt's optimized `mapToScene` method
+- No caching needed (fast enough without)
+
+---
+
+## 10. Code Flow Examples
+
+### 10.1 Creating a Pin on a Cell
+
+```python
+# 1. Create domain entities
+cell = Cell(id=CellId("U1"), name="U1", cell_type="AND2_X1",
+            pin_ids=[PinId("U1.A"), PinId("U1.Y")], is_sequential=False)
+pin = Pin(id=PinId("U1.A"), name="A", direction=PinDirection.INPUT,
+          net_id=NetId("net_001"))
+
+# 2. Create graphics items
+cell_item = CellItem(cell)
+cell_item.setPos(100.0, 200.0)
+scene.addItem(cell_item)
+
+# 3. Create pin as child of cell
+pin_item = PinItem(pin, cell_item)  # Parent-child relationship
+pin_item.setPos(0.0, 20.0)          # Relative to cell
+
+# 4. Pin is automatically in scene (child of cell_item)
+assert pin_item in scene.items()
+
+# 5. Connection point is in scene coordinates
+pt = pin_item.get_connection_point()  # Returns (100, 220)
+```
+
+### 10.2 Zoom Level Change
+
+```python
+# User zooms out to 20%
+zoom_factor = 0.2
+
+# Canvas calculates detail level
+level = DetailLevel.MINIMAL  # Below 25% threshold
+
+# Update all pins
+for item in scene.items():
+    if isinstance(item, PinItem):
+        item.set_detail_level(level)
+        # Pin becomes invisible
+        # boundingRect returns empty
+        # paint returns immediately
+```
+
+---
+
+## 11. Debugging Tips
+
+### 11.1 Checking Connection Points
+
+```python
+# Debug: Print connection points
+for item in scene.items():
+    if isinstance(item, PinItem):
+        pt = item.get_connection_point()
+        print(f"Pin {item.get_pin().name}: ({pt.x()}, {pt.y()})")
+```
+
+### 11.2 Visualizing Pin Bounds
+
+```python
+# Debug: Draw bounding rect
+def paint(self, painter, option, widget):
+    super().paint(painter, option, widget)
+    # Draw debug bounds in red
+    painter.setPen(QPen(QColor("red"), 1))
+    painter.setBrush(Qt.BrushStyle.NoBrush)
+    painter.drawRect(self.boundingRect())
+```
+
+### 11.3 Checking Parent-Child Chain
+
+```python
+# Debug: Verify parent chain
+pin_item = PinItem(pin, cell_item)
+assert pin_item.parentItem() is cell_item
+assert pin_item.scene() is cell_item.scene()
+```
+
+---
+
+## 12. File Structure
+
+```
+src/ink/presentation/canvas/
+├── __init__.py          # Module exports
+├── cell_item.py         # CellItem (parent)
+├── pin_item.py          # PinItem (this implementation)
+└── detail_level.py      # DetailLevel enum
+
+tests/unit/presentation/canvas/
+├── test_cell_item.py    # CellItem tests
+└── test_pin_item.py     # PinItem tests (39 tests)
+```
+
+---
+
+## 13. Summary
+
+The `PinItem` implementation successfully provides:
+
+1. **Visual Representation**: Pins as circles with direction arrows
+2. **Detail Levels**: MINIMAL/BASIC/FULL matching CellItem's LOD
+3. **Connection Points**: Accurate scene coordinates for routing
+4. **Parent-Child Integration**: Coordinate inheritance from CellItem
+
+**Key Design Decisions**:
+- Use Qt's parent-child mechanism for coordinate transformation
+- Use `mapToScene()` for connection point calculation
+- Position labels based on direction (outside cell boundary)
+- Simple polyline arrows for direction indication
+
+**Test Coverage**: 39 tests covering all acceptance criteria
+
+---
+
+## 14. References
+
+- **Spec**: [E02-F01-T02.spec.md](./E02-F01-T02.spec.md)
+- **Pre-docs**: [E02-F01-T02.pre-docs.md](./E02-F01-T02.pre-docs.md)
+- **Post-docs**: [E02-F01-T02.post-docs.md](./E02-F01-T02.post-docs.md)
+- **Qt Documentation**: [QGraphicsItem Parent-Child](https://doc.qt.io/qt-6/qgraphicsitem.html#parent-child-relationship)
+- **Qt Documentation**: [mapToScene](https://doc.qt.io/qt-6/qgraphicsitem.html#mapToScene)

--- a/specs/E02/F01/T02/E02-F01-T02.post-docs.md
+++ b/specs/E02/F01/T02/E02-F01-T02.post-docs.md
@@ -1,0 +1,211 @@
+# E02-F01-T02: Pin Graphics Item - Post-Implementation Documentation
+
+## 1. Implementation Summary
+
+**Spec ID**: E02-F01-T02
+**Title**: Pin Graphics Item
+**Status**: Completed
+**Implementation Date**: 2025-12-28
+
+### What Was Built
+
+A custom `PinItem` class extending `QGraphicsItem` that renders pins (connection points) on cell symbols in the Qt Graphics Scene. PinItem is a child of CellItem, inheriting coordinate transformations for proper scene positioning.
+
+### Key Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| `PinItem` class | `src/ink/presentation/canvas/pin_item.py` | Main graphics item implementation |
+| Unit tests | `tests/unit/presentation/canvas/test_pin_item.py` | 39 comprehensive TDD tests |
+
+---
+
+## 2. Technical Decisions
+
+### 2.1 Parent-Child Hierarchy
+
+**Decision**: PinItem is a child of CellItem via Qt's parent-child mechanism
+**Rationale**:
+- Pins inherit coordinate transformations from parent cell
+- Moving a cell automatically moves all its pins
+- Qt handles visibility inheritance (hiding cell hides pins)
+- Simplifies connection point calculation with `mapToScene()`
+
+### 2.2 Connection Point Calculation
+
+**Decision**: Use `mapToScene()` for connection point coordinates
+**Rationale**:
+- Automatically handles parent-child coordinate chain
+- Accounts for any future transformations (rotation, scaling)
+- Returns accurate scene coordinates for net routing
+- Simple implementation: `mapToScene(QPointF(0, 0))`
+
+### 2.3 Three Detail Levels
+
+**Decision**: MINIMAL (hidden), BASIC (dot only), FULL (dot + label + arrow)
+**Rationale**:
+- Matches CellItem's LOD system for consistency
+- MINIMAL hides pins at low zoom to reduce clutter
+- BASIC shows pin indicators without details for medium zoom
+- FULL shows all information at high zoom for detailed work
+
+### 2.4 Direction Arrow Style
+
+**Decision**: Simple polyline arrows instead of filled triangles
+**Rationale**:
+- Faster to render (fewer primitives)
+- Clear at all zoom levels
+- Consistent with EDA tool conventions
+- INPUT (→), OUTPUT (←), INOUT (↔)
+
+### 2.5 Label Positioning Based on Direction
+
+**Decision**: Position labels outside cell boundary based on direction
+**Rationale**:
+- INPUT pins: label on left (pin is on left edge of cell)
+- OUTPUT pins: label on right (pin is on right edge of cell)
+- INOUT pins: label above pin to avoid ambiguity
+- Prevents overlap with cell name
+
+---
+
+## 3. Architecture Patterns
+
+### 3.1 Parent-Child Coordinate System
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                     QGraphicsScene                              │
+│                    (Scene Coordinates)                          │
+│                                                                 │
+│     CellItem at (100, 200)                                      │
+│     ┌──────────────────────────────────┐                        │
+│     │          Cell Body               │                        │
+│     │                                  │                        │
+│  ●──│  PinItem at (0, 20) relative     │──●                     │
+│     │                                  │                        │
+│  ●──│  Connection point: (100, 220)    │──●                     │
+│     │  in scene coordinates            │                        │
+│     └──────────────────────────────────┘                        │
+│                                                                 │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Detail Level State Machine
+
+```
+         ┌──────────────────────────────────────────┐
+         │              MINIMAL                      │
+         │  - setVisible(False)                      │
+         │  - boundingRect() returns empty           │
+         │  - paint() does nothing                   │
+         └───────────────┬──────────────────────────┘
+                         │ zoom >= 25%
+                         ▼
+         ┌──────────────────────────────────────────┐
+         │               BASIC                       │
+         │  - setVisible(True)                       │
+         │  - Renders pin circle only                │
+         │  - Small bounding rect                    │
+         └───────────────┬──────────────────────────┘
+                         │ zoom >= 75%
+                         ▼
+         ┌──────────────────────────────────────────┐
+         │               FULL                        │
+         │  - Renders circle + label + arrow         │
+         │  - Large bounding rect                    │
+         │  - Full visual detail                     │
+         └──────────────────────────────────────────┘
+```
+
+---
+
+## 4. Code Quality Metrics
+
+### 4.1 Test Coverage
+
+| Category | Tests | Coverage |
+|----------|-------|----------|
+| Creation | 5 | Constructor, subclass, pin reference, parent, default level |
+| Constants | 3 | PIN_RADIUS, ARROW_SIZE, LABEL_OFFSET |
+| Bounding Rect | 5 | Return type, minimal, basic, full, long name |
+| Detail Level | 4 | Minimal hides, basic shows, full shows, triggers update |
+| Connection Point | 5 | Return type, origin, pin position, parent position, parent movement |
+| Direction Arrows | 3 | Input, output, inout directions |
+| Paint | 6 | Method exists, no error, minimal/basic/full levels, all directions |
+| Scene Integration | 3 | Appears in scene, multiple pins, parent visibility |
+| Edge Cases | 3 | Floating pin, empty name, same level no update |
+| Performance | 2 | Creation speed, connection point speed |
+| **Total** | **39** | **100% of acceptance criteria** |
+
+### 4.2 Linting Results
+
+- **ruff**: All checks passed
+- **mypy**: No issues found
+- **pytest**: 39/39 tests pass
+
+---
+
+## 5. Lessons Learned
+
+### 5.1 Qt Parent-Child Hierarchy Benefits
+
+**Observation**: Using parent-child relationship simplified coordinate handling significantly
+**Learning**: Always use Qt's built-in parent-child mechanism when graphics items have logical parent-child relationships. The coordinate transformation chain (`mapToScene`, `mapToParent`) handles all the complexity.
+
+### 5.2 Type Consistency in Conditional Branches
+
+**Issue**: mypy flagged type mismatch when assigning `int` in one branch and `float` in another
+**Learning**: When a variable can hold different numeric values in conditional branches, use consistent types (all `float` or all `int`) to avoid type inference issues.
+
+### 5.3 Test Fixture Dependency Management
+
+**Issue**: ruff flagged too many arguments (PLR0913) when a test needed many fixtures
+**Learning**: Create domain objects directly in tests when multiple similar objects are needed, rather than using separate fixtures for each. This reduces parameter count while maintaining test clarity.
+
+---
+
+## 6. Future Improvements
+
+### 6.1 Planned Enhancements
+
+1. **E02-F01-T03**: SymbolLayoutCalculator - Will calculate pin positions automatically
+2. **E02-F01-T04**: Zoom LOD System - Will call `set_detail_level()` based on zoom
+3. **E02-F03**: Net Router - Will use `get_connection_point()` for routing
+
+### 6.2 Potential Optimizations
+
+- **Text elision**: Use `QFontMetrics.elidedText()` for very long pin names
+- **Batch arrow rendering**: Pre-calculate arrow polygons as class-level constants
+- **Label caching**: Cache text width calculations for repeated use
+
+---
+
+## 7. Dependencies and Integration
+
+### 7.1 Upstream Dependencies
+
+| Dependency | Purpose | Status |
+|------------|---------|--------|
+| `Pin` domain entity | Data source for pin properties | Available |
+| `PinDirection` enum | Direction information | Available |
+| `CellItem` class | Parent graphics item | Available |
+| `DetailLevel` enum | LOD control | Available |
+| PySide6 `QGraphicsItem` | Base class for rendering | Available |
+
+### 7.2 Downstream Dependents
+
+| Dependent | Purpose | Status |
+|-----------|---------|--------|
+| E02-F01-T03: SymbolLayoutCalculator | Will position pins on cells | Completed |
+| E02-F01-T04: Zoom LOD | Will control pin detail levels | Planned |
+| E02-F03: Net Router | Will use connection points | Planned |
+
+---
+
+## 8. References
+
+- **Spec**: [E02-F01-T02.spec.md](./E02-F01-T02.spec.md)
+- **Pre-docs**: [E02-F01-T02.pre-docs.md](./E02-F01-T02.pre-docs.md)
+- **ClickUp Task**: `CU-86evzm2hj`
+- **Implementation Narrative**: [E02-F01-T02-implementation-narrative.md](./E02-F01-T02-implementation-narrative.md)

--- a/specs/E02/F01/T02/E02-F01-T02.spec.md
+++ b/specs/E02/F01/T02/E02-F01-T02.spec.md
@@ -3,7 +3,7 @@ id: E02-F01-T02
 title: Pin Graphics Item
 type: Task
 priority: P0 (MVP)
-status: Draft
+status: Completed
 parent: E02-F01
 created: 2025-12-26
 estimated_hours: 6
@@ -147,16 +147,16 @@ Position determined by `SymbolLayoutCalculator` (T03).
 
 ## 4. Acceptance Criteria
 
-- [ ] `PinItem` class implemented in `presentation/canvas/pin_item.py`
-- [ ] Renders as small circle on cell edge
-- [ ] Pin name label displayed at FULL detail level
-- [ ] Direction arrows shown correctly (input/output/inout)
-- [ ] Connection point calculation returns correct scene coordinates
-- [ ] Detail level transitions smoothly based on zoom
-- [ ] Pin indicators (dots) visible at BASIC level
-- [ ] All pin details hidden at MINIMAL level
-- [ ] Unit tests verify rendering for each detail level
-- [ ] Integration test shows pins on cell in scene
+- [x] `PinItem` class implemented in `presentation/canvas/pin_item.py`
+- [x] Renders as small circle on cell edge
+- [x] Pin name label displayed at FULL detail level
+- [x] Direction arrows shown correctly (input/output/inout)
+- [x] Connection point calculation returns correct scene coordinates
+- [x] Detail level transitions smoothly based on zoom
+- [x] Pin indicators (dots) visible at BASIC level
+- [x] All pin details hidden at MINIMAL level
+- [x] Unit tests verify rendering for each detail level
+- [x] Integration test shows pins on cell in scene
 
 ---
 

--- a/src/ink/presentation/canvas/pin_item.py
+++ b/src/ink/presentation/canvas/pin_item.py
@@ -1,0 +1,513 @@
+"""PinItem graphics item for pin rendering on cell symbols.
+
+This module provides the PinItem class, a custom QGraphicsItem subclass that
+renders pins (connection points) on cell symbols in the schematic canvas.
+PinItem is the visual representation of a Pin domain entity.
+
+Architecture Notes:
+    - PinItem lives in the presentation layer
+    - It is a child of CellItem for coordinate inheritance
+    - It wraps a Pin domain entity but contains no domain logic
+    - All rendering, interaction, and visual state logic is encapsulated here
+    - Follows Qt's QGraphicsItem pattern for scene-based graphics
+
+Visual Specifications:
+    - Pin body: Small circle (3px radius) on cell edges
+    - Color: Dark gray (#333333)
+    - Direction arrows at FULL detail level:
+        - INPUT: Arrow pointing into cell (→)
+        - OUTPUT: Arrow pointing out of cell (←)
+        - INOUT: Bidirectional arrow (↔)
+    - Pin name label: Sans-serif 8pt, positioned adjacent to pin
+
+Level of Detail (LOD) Rendering:
+    - MINIMAL: Pin hidden completely (not rendered)
+    - BASIC: Pin circle only (no label, no arrow)
+    - FULL: Pin circle + name label + direction arrow
+
+Performance Considerations:
+    - Simple rendering primitives for efficiency
+    - Connection point calculation uses Qt's mapToScene() for accuracy
+    - Bounding rect adapts to detail level for optimal culling
+
+See Also:
+    - Spec E02-F01-T02 for detailed requirements
+    - src/ink/domain/model/pin.py for Pin domain entity
+    - src/ink/presentation/canvas/cell_item.py for parent CellItem
+
+Example:
+    >>> from ink.domain.model.pin import Pin
+    >>> from ink.domain.value_objects.identifiers import PinId, NetId
+    >>> from ink.domain.value_objects.pin_direction import PinDirection
+    >>> from ink.presentation.canvas.pin_item import PinItem
+    >>> from ink.presentation.canvas.cell_item import CellItem
+    >>>
+    >>> # Create domain pin
+    >>> pin = Pin(
+    ...     id=PinId("U1.A"),
+    ...     name="A",
+    ...     direction=PinDirection.INPUT,
+    ...     net_id=NetId("net_001")
+    ... )
+    >>>
+    >>> # Create graphics item as child of cell item
+    >>> cell_item = CellItem(cell)
+    >>> pin_item = PinItem(pin, cell_item)
+    >>> pin_item.setPos(0.0, 20.0)  # Position relative to cell
+    >>>
+    >>> # Get connection point for net routing
+    >>> connection_point = pin_item.get_connection_point()
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QPointF, QRectF
+from PySide6.QtGui import (
+    QBrush,
+    QColor,
+    QFont,
+    QPainter,
+    QPen,
+    QPolygonF,
+)
+from PySide6.QtWidgets import (
+    QGraphicsItem,
+    QStyleOptionGraphicsItem,
+    QWidget,
+)
+
+from ink.domain.value_objects.pin_direction import PinDirection
+from ink.presentation.canvas.detail_level import DetailLevel
+
+if TYPE_CHECKING:
+    from ink.domain.model.pin import Pin
+
+
+class PinItem(QGraphicsItem):
+    """QGraphicsItem representing a pin on a cell symbol.
+
+    PinItem renders connection points on cell symbols as small circles with
+    optional direction arrows and name labels. It is a child of CellItem,
+    inheriting coordinate transformations for proper scene positioning.
+
+    The item supports three detail levels:
+    - MINIMAL: Hidden (not rendered)
+    - BASIC: Circle only
+    - FULL: Circle + name label + direction arrow
+
+    Class Constants:
+        PIN_RADIUS: Radius of the pin circle in pixels (3.0)
+        PIN_COLOR: Color for pin circle and arrows (dark gray #333333)
+        ARROW_SIZE: Size of direction arrows in pixels (8.0)
+        LABEL_OFFSET: Offset between pin and label in pixels (5.0)
+        LABEL_FONT_SIZE: Font size for pin labels in points (8)
+
+    Attributes:
+        _pin: The domain Pin entity this item represents
+        _detail_level: Current detail level for rendering
+
+    Args:
+        pin: Domain Pin entity to visualize
+        parent_cell_item: Parent CellItem for coordinate inheritance
+
+    Example:
+        >>> pin = Pin(id=PinId("U1.A"), name="A", direction=PinDirection.INPUT,
+        ...           net_id=NetId("net_001"))
+        >>> cell_item = CellItem(cell)
+        >>> pin_item = PinItem(pin, cell_item)
+        >>> pin_item.setPos(0.0, 20.0)
+        >>> connection_pt = pin_item.get_connection_point()
+    """
+
+    # ==========================================================================
+    # Class Constants - Geometry
+    # ==========================================================================
+    # These values define the pin visual dimensions as specified in E02-F01-T02.
+
+    PIN_RADIUS: float = 3.0
+    """Radius of the pin circle in pixels. Small for compact appearance."""
+
+    ARROW_SIZE: float = 8.0
+    """Size of direction arrows in pixels. Visible but not overwhelming."""
+
+    LABEL_OFFSET: float = 5.0
+    """Offset between pin circle and label text in pixels."""
+
+    LABEL_FONT_SIZE: int = 8
+    """Font size for pin name labels in points. Smaller than cell names."""
+
+    # ==========================================================================
+    # Class Constants - Colors
+    # ==========================================================================
+    # Color palette follows the spec for consistent appearance.
+
+    PIN_COLOR = QColor("#333333")
+    """Dark gray color for pin circle and direction arrows."""
+
+    _LABEL_COLOR = QColor("#000000")
+    """Black color for pin name labels."""
+
+    def __init__(
+        self, pin: Pin, parent_cell_item: QGraphicsItem
+    ) -> None:
+        """Initialize pin graphics item.
+
+        Sets up the item as a child of the parent cell item for proper
+        coordinate inheritance. The pin position should be set via setPos()
+        after construction (typically by SymbolLayoutCalculator).
+
+        Args:
+            pin: Domain pin entity containing pin data (name, direction)
+            parent_cell_item: Parent CellItem for coordinate inheritance.
+                Pin positions are relative to the parent cell's origin.
+        """
+        # Initialize as child of parent cell item
+        # This establishes the parent-child relationship for coordinate transforms
+        super().__init__(parent_cell_item)
+
+        # Store reference to domain entity for property queries
+        # The pin provides name, direction, and connection info
+        self._pin = pin
+
+        # Default to FULL detail level for maximum visibility
+        # SchematicCanvas will update this based on zoom level (T04)
+        self._detail_level = DetailLevel.FULL
+
+    # ==========================================================================
+    # QGraphicsItem Required Methods
+    # ==========================================================================
+
+    def boundingRect(self) -> QRectF:
+        """Return the bounding rectangle for collision detection and rendering.
+
+        The bounding rect must encompass all painted areas including the pin
+        circle, direction arrow, and name label. The size varies based on
+        the current detail level:
+        - MINIMAL: Empty rect (nothing rendered)
+        - BASIC: Small rect for pin circle only
+        - FULL: Larger rect including label and arrow
+
+        Returns:
+            QRectF: Rectangle encompassing the entire painted area.
+                    Empty rect if detail level is MINIMAL.
+
+        Note:
+            Qt uses this rect for:
+            - Collision detection (item at point queries)
+            - Scene update optimization (dirty region tracking)
+            - View culling (items outside view aren't painted)
+        """
+        # MINIMAL level: Pin is hidden, return empty bounds
+        if self._detail_level == DetailLevel.MINIMAL:
+            return QRectF()
+
+        # BASIC level: Only pin circle, small bounds
+        if self._detail_level == DetailLevel.BASIC:
+            return QRectF(
+                -self.PIN_RADIUS,
+                -self.PIN_RADIUS,
+                self.PIN_RADIUS * 2,
+                self.PIN_RADIUS * 2,
+            )
+
+        # FULL level: Include label and arrow extents
+        # Start with pin circle bounds
+        bounds = QRectF(
+            -self.PIN_RADIUS,
+            -self.PIN_RADIUS,
+            self.PIN_RADIUS * 2,
+            self.PIN_RADIUS * 2,
+        )
+
+        # Calculate label and arrow extents based on direction
+        arrow_extent = self.ARROW_SIZE + 2
+        label_extent = self._estimate_label_width() + self.LABEL_OFFSET
+
+        # Expand bounds based on pin direction
+        # Input pins have arrows on the right, labels on the left
+        # Output pins have arrows on the left, labels on the right
+        # Inout pins have arrows on both sides
+        if self._pin.direction == PinDirection.INPUT:
+            # Arrow points right (into cell), label on left
+            bounds.adjust(-label_extent, -5, arrow_extent, 5)
+        elif self._pin.direction == PinDirection.OUTPUT:
+            # Arrow points left (out of cell), label on right
+            bounds.adjust(-arrow_extent, -5, label_extent, 5)
+        else:  # INOUT
+            # Bidirectional, expand both sides
+            extent = max(arrow_extent, label_extent)
+            bounds.adjust(-extent, -5, extent, 5)
+
+        return bounds
+
+    def paint(
+        self,
+        painter: QPainter,
+        _option: QStyleOptionGraphicsItem,
+        _widget: QWidget | None = None,
+    ) -> None:
+        """Render the pin with appropriate detail level.
+
+        Draws the pin based on the current detail level:
+        - MINIMAL: Nothing (hidden)
+        - BASIC: Pin circle only
+        - FULL: Pin circle + name label + direction arrow
+
+        Args:
+            painter: QPainter configured for rendering
+            _option: Style options (unused for pins)
+            _widget: Target widget (may be None for off-screen rendering)
+
+        Note:
+            This method is called by Qt's graphics view framework whenever
+            the item needs repainting. Keep it efficient for smooth scrolling.
+        """
+        # MINIMAL level: Don't render anything
+        if self._detail_level == DetailLevel.MINIMAL:
+            return
+
+        # =======================================================================
+        # Draw Pin Circle (BASIC and FULL levels)
+        # =======================================================================
+        # Pin is rendered as a small filled circle at the item's origin
+        painter.setPen(QPen(self.PIN_COLOR, 1))
+        painter.setBrush(QBrush(self.PIN_COLOR))
+        painter.drawEllipse(QPointF(0, 0), self.PIN_RADIUS, self.PIN_RADIUS)
+
+        # BASIC level: Stop here (no label, no arrow)
+        if self._detail_level == DetailLevel.BASIC:
+            return
+
+        # =======================================================================
+        # FULL level: Draw label and direction arrow
+        # =======================================================================
+        self._draw_label(painter)
+        self._draw_direction_arrow(painter)
+
+    def _draw_label(self, painter: QPainter) -> None:
+        """Draw pin name label adjacent to pin.
+
+        Positions the label based on pin direction to avoid overlap with
+        the cell body:
+        - INPUT: Label on left (outside cell)
+        - OUTPUT: Label on right (outside cell)
+        - INOUT: Label above pin
+
+        Args:
+            painter: QPainter to draw with
+        """
+        # Skip if pin name is empty
+        if not self._pin.name:
+            return
+
+        # Configure font and color
+        painter.setPen(self._LABEL_COLOR)
+        font = QFont("sans-serif", self.LABEL_FONT_SIZE)
+        painter.setFont(font)
+
+        # Position label based on pin direction
+        if self._pin.direction == PinDirection.INPUT:
+            # Input pins: label on left (outside cell, since pin is on left edge)
+            label_x = -self.LABEL_OFFSET - self._estimate_label_width()
+            label_y = 4.0  # Vertically centered (font baseline adjustment)
+            painter.drawText(QPointF(label_x, label_y), self._pin.name)
+
+        elif self._pin.direction == PinDirection.OUTPUT:
+            # Output pins: label on right (outside cell, since pin is on right edge)
+            label_x = self.LABEL_OFFSET
+            label_y = 4.0  # Vertically centered
+            painter.drawText(QPointF(label_x, label_y), self._pin.name)
+
+        else:  # INOUT
+            # Inout pins: label above pin to avoid ambiguity
+            label_x = -self._estimate_label_width() / 2
+            label_y = -self.LABEL_OFFSET
+            painter.drawText(QPointF(label_x, label_y), self._pin.name)
+
+    def _draw_direction_arrow(self, painter: QPainter) -> None:
+        """Draw direction arrow based on pin type.
+
+        Arrows indicate signal flow direction:
+        - INPUT: Arrow pointing into cell (rightward →)
+        - OUTPUT: Arrow pointing out of cell (leftward ←)
+        - INOUT: Bidirectional arrows (↔)
+
+        Args:
+            painter: QPainter to draw with
+        """
+        painter.setPen(QPen(self.PIN_COLOR, 1))
+        painter.setBrush(QBrush(self.PIN_COLOR))
+
+        if self._pin.direction == PinDirection.INPUT:
+            self._draw_input_arrow(painter)
+        elif self._pin.direction == PinDirection.OUTPUT:
+            self._draw_output_arrow(painter)
+        else:  # INOUT
+            self._draw_bidirectional_arrow(painter)
+
+    def _draw_input_arrow(self, painter: QPainter) -> None:
+        """Draw arrow pointing into cell (rightward →).
+
+        Arrow starts from the right of the pin circle and points right,
+        indicating signal flow into the cell.
+
+        Args:
+            painter: QPainter to draw with
+        """
+        # Arrow baseline starts after pin circle with small gap
+        base_x = self.PIN_RADIUS + 2
+
+        # Create arrow as polyline: base → tip → upper barb → tip → lower barb
+        arrow = QPolygonF([
+            QPointF(base_x, 0),                          # Arrow base
+            QPointF(base_x + self.ARROW_SIZE, 0),        # Arrow tip
+            QPointF(base_x + self.ARROW_SIZE - 3, -3),   # Upper barb
+            QPointF(base_x + self.ARROW_SIZE, 0),        # Back to tip
+            QPointF(base_x + self.ARROW_SIZE - 3, 3),    # Lower barb
+        ])
+        painter.drawPolyline(arrow)
+
+    def _draw_output_arrow(self, painter: QPainter) -> None:
+        """Draw arrow pointing out of cell (leftward ←).
+
+        Arrow starts from the left of the pin circle and points left,
+        indicating signal flow out of the cell.
+
+        Args:
+            painter: QPainter to draw with
+        """
+        # Arrow baseline starts before pin circle with small gap
+        base_x = -self.PIN_RADIUS - 2
+
+        # Create arrow as polyline: base → tip → upper barb → tip → lower barb
+        arrow = QPolygonF([
+            QPointF(base_x, 0),                          # Arrow base
+            QPointF(base_x - self.ARROW_SIZE, 0),        # Arrow tip
+            QPointF(base_x - self.ARROW_SIZE + 3, -3),   # Upper barb
+            QPointF(base_x - self.ARROW_SIZE, 0),        # Back to tip
+            QPointF(base_x - self.ARROW_SIZE + 3, 3),    # Lower barb
+        ])
+        painter.drawPolyline(arrow)
+
+    def _draw_bidirectional_arrow(self, painter: QPainter) -> None:
+        """Draw bidirectional arrow for INOUT pins (↔).
+
+        Draws both input and output arrows to indicate bidirectional
+        signal flow.
+
+        Args:
+            painter: QPainter to draw with
+        """
+        # Draw both arrows
+        self._draw_input_arrow(painter)
+        self._draw_output_arrow(painter)
+
+    def _estimate_label_width(self) -> float:
+        """Estimate label width for bounding rect calculation.
+
+        Uses a rough estimate of 6 pixels per character for efficiency.
+        Actual font metrics would be more accurate but slower.
+
+        Returns:
+            float: Estimated label width in pixels
+        """
+        # Rough estimate: approximately 6 pixels per character
+        # This is conservative to ensure the bounding rect is large enough
+        return len(self._pin.name) * 6
+
+    # ==========================================================================
+    # Public API Methods
+    # ==========================================================================
+
+    def get_connection_point(self) -> QPointF:
+        """Return the scene coordinate for net attachment.
+
+        The connection point is the center of the pin circle, converted to
+        scene coordinates. This is critical for net routing - the router
+        uses this point to determine where nets should connect.
+
+        Returns:
+            QPointF: Connection point in scene coordinates
+
+        Note:
+            Uses Qt's mapToScene() to account for:
+            - Pin's position relative to parent cell
+            - Parent cell's position in the scene
+            - Any transformations (rotation, scaling)
+
+        Example:
+            >>> # Cell at (100, 200), pin at (10, 20) relative to cell
+            >>> connection_point = pin_item.get_connection_point()
+            >>> # Returns (110, 220) in scene coordinates
+        """
+        # Pin center is at item origin (0, 0)
+        item_pos = QPointF(0, 0)
+
+        # Convert to scene coordinates (handles full transformation chain)
+        scene_pos = self.mapToScene(item_pos)
+
+        return scene_pos
+
+    def set_detail_level(self, level: DetailLevel) -> None:
+        """Set the level of detail based on zoom.
+
+        Changes the rendering detail level and updates visibility:
+        - MINIMAL: Hides the pin (setVisible(False))
+        - BASIC: Shows pin circle only
+        - FULL: Shows pin circle, label, and arrow
+
+        Args:
+            level: New DetailLevel value
+
+        Note:
+            Typically called by SchematicCanvas when zoom changes (T04).
+            Triggers a repaint to update the visual appearance.
+
+        Example:
+            >>> pin_item.set_detail_level(DetailLevel.FULL)  # Show all details
+            >>> pin_item.set_detail_level(DetailLevel.MINIMAL)  # Hide pin
+        """
+        # Skip if level hasn't changed to avoid unnecessary repaints
+        if self._detail_level == level:
+            return
+
+        self._detail_level = level
+
+        # Update visibility based on level
+        # MINIMAL = hidden, BASIC/FULL = visible
+        self.setVisible(level != DetailLevel.MINIMAL)
+
+        # Trigger repaint to update rendering
+        self.update()
+
+    def get_pin(self) -> Pin:
+        """Return the associated domain pin entity.
+
+        Provides access to the underlying Pin for property queries,
+        such as displaying pin properties in a property panel or
+        determining net connectivity.
+
+        Returns:
+            The Pin domain entity this item visualizes
+
+        Example:
+            >>> pin = pin_item.get_pin()
+            >>> print(f"Pin direction: {pin.direction}")
+            >>> print(f"Connected net: {pin.net_id}")
+        """
+        return self._pin
+
+    def __repr__(self) -> str:
+        """Return string representation for debugging.
+
+        Returns:
+            String like: PinItem(name='A', direction=INPUT, pos=(10.0, 20.0))
+        """
+        pos = self.pos()
+        return (
+            f"PinItem(name={self._pin.name!r}, "
+            f"direction={self._pin.direction.name}, "
+            f"pos=({pos.x()}, {pos.y()}))"
+        )

--- a/tests/integration/presentation/test_toolbar_icons.py
+++ b/tests/integration/presentation/test_toolbar_icons.py
@@ -27,6 +27,8 @@ from ink.infrastructure.persistence.app_settings import AppSettings
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
 
+    from ink.presentation.main_window import InkMainWindow
+
 
 @pytest.fixture
 def app_settings() -> AppSettings:
@@ -35,7 +37,7 @@ def app_settings() -> AppSettings:
 
 
 @pytest.fixture
-def main_window(qtbot: QtBot, app_settings: AppSettings):
+def main_window(qtbot: "QtBot", app_settings: AppSettings) -> "InkMainWindow":
     """Create main window instance with toolbar."""
     from ink.presentation.main_window import InkMainWindow
 
@@ -47,14 +49,15 @@ def main_window(qtbot: QtBot, app_settings: AppSettings):
 class TestToolbarIconsPresent:
     """Test that all toolbar buttons have icons."""
 
-    def test_toolbar_exists(self, main_window) -> None:
+    def test_toolbar_exists(self, main_window: "InkMainWindow") -> None:
         """Main window should have a toolbar named 'MainToolBar'."""
         toolbar = main_window.findChild(QToolBar, "MainToolBar")
         assert toolbar is not None, "MainToolBar not found"
 
-    def test_all_toolbar_buttons_have_icons(self, main_window) -> None:
+    def test_all_toolbar_buttons_have_icons(self, main_window: "InkMainWindow") -> None:
         """All toolbar buttons (non-separator actions) should have icons."""
         toolbar = main_window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
 
         actions_without_icons = []
         for action in toolbar.actions():
@@ -67,25 +70,25 @@ class TestToolbarIconsPresent:
             f"Actions without icons: {actions_without_icons}"
         )
 
-    def test_open_action_has_icon(self, main_window) -> None:
+    def test_open_action_has_icon(self, main_window: "InkMainWindow") -> None:
         """Open action should have an icon."""
         assert hasattr(main_window, "_open_action")
         icon = main_window._open_action.icon()
         assert not icon.isNull(), "Open action should have an icon"
 
-    def test_undo_action_has_icon(self, main_window) -> None:
+    def test_undo_action_has_icon(self, main_window: "InkMainWindow") -> None:
         """Undo action should have an icon."""
         assert hasattr(main_window, "_undo_action")
         icon = main_window._undo_action.icon()
         assert not icon.isNull(), "Undo action should have an icon"
 
-    def test_redo_action_has_icon(self, main_window) -> None:
+    def test_redo_action_has_icon(self, main_window: "InkMainWindow") -> None:
         """Redo action should have an icon."""
         assert hasattr(main_window, "_redo_action")
         icon = main_window._redo_action.icon()
         assert not icon.isNull(), "Redo action should have an icon"
 
-    def test_search_action_has_icon(self, main_window) -> None:
+    def test_search_action_has_icon(self, main_window: "InkMainWindow") -> None:
         """Search action should have an icon."""
         assert hasattr(main_window, "_search_action")
         icon = main_window._search_action.icon()
@@ -95,13 +98,14 @@ class TestToolbarIconsPresent:
 class TestToolbarIconsQuality:
     """Test quality of toolbar icons."""
 
-    def test_icons_are_not_null(self, main_window) -> None:
+    def test_icons_are_not_null(self, main_window: "InkMainWindow") -> None:
         """All toolbar icons should be valid QIcon instances (not null).
 
         Note: SVG icons may not report availableSizes() in offscreen mode,
         so we test that icons are not null instead.
         """
         toolbar = main_window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
 
         for action in toolbar.actions():
             if not action.isSeparator():
@@ -110,9 +114,10 @@ class TestToolbarIconsQuality:
                     f"Action '{action.text()}' icon should not be null"
                 )
 
-    def test_icons_render_at_toolbar_size(self, main_window) -> None:
+    def test_icons_render_at_toolbar_size(self, main_window: "InkMainWindow") -> None:
         """Icons should render at toolbar icon size (24x24) without being null."""
         toolbar = main_window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         expected_size = QSize(24, 24)
 
         for action in toolbar.actions():
@@ -124,9 +129,10 @@ class TestToolbarIconsQuality:
                         f"Action '{action.text()}' icon failed to render at 24x24"
                     )
 
-    def test_icons_render_at_larger_size(self, main_window) -> None:
+    def test_icons_render_at_larger_size(self, main_window: "InkMainWindow") -> None:
         """Icons should scale cleanly to larger sizes (32x32)."""
         toolbar = main_window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         larger_size = QSize(32, 32)
 
         for action in toolbar.actions():
@@ -142,7 +148,7 @@ class TestToolbarIconsQuality:
 class TestIconProviderIntegration:
     """Test that IconProvider is properly integrated with main window."""
 
-    def test_icon_provider_used_for_open_action(self, main_window) -> None:
+    def test_icon_provider_used_for_open_action(self, main_window: "InkMainWindow") -> None:
         """Open action icon should be loaded via IconProvider (not null)."""
         from ink.presentation.utils.icon_provider import IconProvider
 
@@ -156,7 +162,7 @@ class TestIconProviderIntegration:
         assert not provider_icon.isNull()
         assert not action_icon.isNull()
 
-    def test_icon_provider_used_for_zoom_actions(self, main_window) -> None:
+    def test_icon_provider_used_for_zoom_actions(self, main_window: "InkMainWindow") -> None:
         """Zoom actions should use icons from IconProvider."""
         from ink.presentation.utils.icon_provider import IconProvider
 
@@ -183,6 +189,7 @@ class TestToolbarIconsFallback:
         qtbot.addWidget(window)
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
 
         # Check all actions have icons
         for action in toolbar.actions():

--- a/tests/unit/domain/model/test_cell.py
+++ b/tests/unit/domain/model/test_cell.py
@@ -6,8 +6,9 @@ Cell is a frozen dataclass with helper methods for identifying sequential elemen
 The Cell entity is a core domain concept representing gate instances in a netlist.
 """
 
-import pytest
 from dataclasses import FrozenInstanceError
+
+import pytest
 
 from ink.domain.model.cell import Cell
 from ink.domain.value_objects.identifiers import CellId, PinId

--- a/tests/unit/domain/model/test_cell.py
+++ b/tests/unit/domain/model/test_cell.py
@@ -159,7 +159,7 @@ class TestCellImmutability:
         )
 
         with pytest.raises(FrozenInstanceError):
-            cell.pin_ids = [PinId("XI1.B")]  # type: ignore[misc]
+            cell.pin_ids = [PinId("XI1.B")]  # type: ignore[misc, assignment]
 
     def test_cell_is_sequential_cannot_be_reassigned(self) -> None:
         """Should raise error when trying to reassign is_sequential on frozen Cell."""

--- a/tests/unit/domain/model/test_net_entity.py
+++ b/tests/unit/domain/model/test_net_entity.py
@@ -10,8 +10,9 @@ Note: This file is named test_net_entity.py to avoid conflict with the existing
 test_net.py that tests NetInfo value object.
 """
 
-import pytest
 from dataclasses import FrozenInstanceError
+
+import pytest
 
 from ink.domain.model.net import Net
 from ink.domain.value_objects.identifiers import NetId, PinId

--- a/tests/unit/domain/model/test_net_entity.py
+++ b/tests/unit/domain/model/test_net_entity.py
@@ -175,7 +175,7 @@ class TestNetImmutability:
         )
 
         with pytest.raises(FrozenInstanceError):
-            net.connected_pin_ids = [PinId("XI2.A")]  # type: ignore[misc]
+            net.connected_pin_ids = [PinId("XI2.A")]  # type: ignore[misc, assignment]
 
     def test_net_connected_pin_ids_tuple_is_immutable(self) -> None:
         """connected_pin_ids should be a tuple (immutable)."""

--- a/tests/unit/domain/model/test_pin.py
+++ b/tests/unit/domain/model/test_pin.py
@@ -8,11 +8,12 @@ The Pin entity is a core domain concept used in graph traversal to determine
 connectivity between cells via nets.
 """
 
-import pytest
 from dataclasses import FrozenInstanceError
 
+import pytest
+
 from ink.domain.model.pin import Pin
-from ink.domain.value_objects.identifiers import PinId, NetId
+from ink.domain.value_objects.identifiers import NetId, PinId
 from ink.domain.value_objects.pin_direction import PinDirection
 
 

--- a/tests/unit/domain/model/test_port.py
+++ b/tests/unit/domain/model/test_port.py
@@ -7,11 +7,12 @@ The Port entity is a core domain concept for representing the external
 interface of a design (inputs, outputs, and bidirectional pins).
 """
 
-import pytest
 from dataclasses import FrozenInstanceError
 
+import pytest
+
 from ink.domain.model.port import Port
-from ink.domain.value_objects.identifiers import PortId, NetId
+from ink.domain.value_objects.identifiers import NetId, PortId
 from ink.domain.value_objects.pin_direction import PinDirection
 
 

--- a/tests/unit/domain/services/test_graph_traverser.py
+++ b/tests/unit/domain/services/test_graph_traverser.py
@@ -36,7 +36,7 @@ class TestGraphTraverserProtocol:
         from ink.domain.services import GraphTraverser
 
         # Check that it's a Protocol subclass
-        assert issubclass(GraphTraverser, Protocol)
+        assert issubclass(GraphTraverser, Protocol)  # type: ignore[arg-type]
 
     def test_graph_traverser_is_runtime_checkable(self) -> None:
         """GraphTraverser should be runtime_checkable for isinstance checks."""

--- a/tests/unit/domain/value_objects/test_identifiers.py
+++ b/tests/unit/domain/value_objects/test_identifiers.py
@@ -127,4 +127,5 @@ class TestIdentifierTypeDistinction:
 
         # At runtime, they're all equal strings
         # Type safety is enforced at compile time by mypy
-        assert cell_id == net_id == pin_id == port_id == "test"
+        # Intentionally comparing different types to verify runtime equality
+        assert cell_id == net_id == pin_id == port_id == "test"  # type: ignore[comparison-overlap]

--- a/tests/unit/domain/value_objects/test_pin_direction.py
+++ b/tests/unit/domain/value_objects/test_pin_direction.py
@@ -127,9 +127,10 @@ class TestPinDirectionEquality:
 
     def test_different_members_are_not_equal(self) -> None:
         """Different enum members should not be equal."""
-        assert PinDirection.INPUT != PinDirection.OUTPUT
-        assert PinDirection.INPUT != PinDirection.INOUT
-        assert PinDirection.OUTPUT != PinDirection.INOUT
+        # Intentionally comparing different enum members
+        assert PinDirection.INPUT != PinDirection.OUTPUT  # type: ignore[comparison-overlap]
+        assert PinDirection.INPUT != PinDirection.INOUT  # type: ignore[comparison-overlap]
+        assert PinDirection.OUTPUT != PinDirection.INOUT  # type: ignore[comparison-overlap]
 
 
 class TestPinDirectionIsInputMethod:

--- a/tests/unit/infrastructure/config/test_latch_config.py
+++ b/tests/unit/infrastructure/config/test_latch_config.py
@@ -101,7 +101,7 @@ class TestLatchIdentificationConfigDataclass:
         # Test that it's frozen by attempting modification
         config = LatchIdentificationConfig(patterns=["*DFF*"], case_sensitive=False)
         with pytest.raises(AttributeError):
-            config.patterns = ["*LATCH*"]  # type: ignore[misc]
+            config.patterns = ["*LATCH*"]  # type: ignore[misc, assignment]
 
     def test_config_has_patterns_field(self) -> None:
         """Test that config has 'patterns' field as a sequence of strings."""

--- a/tests/unit/infrastructure/config/test_net_classification_config.py
+++ b/tests/unit/infrastructure/config/test_net_classification_config.py
@@ -16,9 +16,10 @@ See Also:
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pytest
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestNetClassificationConfigLoad:
@@ -189,11 +190,11 @@ class TestNetClassificationConfigSave:
 
     def test_save_writes_valid_yaml(self, tmp_path: Path) -> None:
         """Test that saved YAML can be parsed back."""
+        import yaml
+
         from ink.infrastructure.config.net_classification_config import (
             NetClassificationConfig,
         )
-
-        import yaml
 
         config = NetClassificationConfig(
             power_names=["AVDD", "DVDD"],

--- a/tests/unit/infrastructure/graph/test_networkx_traverser.py
+++ b/tests/unit/infrastructure/graph/test_networkx_traverser.py
@@ -22,9 +22,17 @@ Architecture:
     Implements: GraphTraverser protocol from domain layer
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from ink.domain.model import Cell, Design, Net, Pin
+
+if TYPE_CHECKING:
+    from ink.infrastructure.graph import NetworkXGraphTraverser
+
 from ink.domain.value_objects.identifiers import CellId, NetId, PinId
 from ink.domain.value_objects.pin_direction import PinDirection
 from ink.infrastructure.graph import NetworkXGraphBuilder
@@ -372,7 +380,7 @@ def cycle_design() -> Design:
     return design
 
 
-def build_traverser(design: Design):
+def build_traverser(design: Design) -> "NetworkXGraphTraverser":
     """Helper to build graph and traverser from design."""
     from ink.infrastructure.graph import NetworkXGraphTraverser
 

--- a/tests/unit/infrastructure/identification/test_topology_latch_identifier.py
+++ b/tests/unit/infrastructure/identification/test_topology_latch_identifier.py
@@ -28,7 +28,6 @@ from ink.infrastructure.identification.topology_latch_identifier import (
     TopologyBasedLatchIdentifier,
 )
 
-
 # =============================================================================
 # FEEDBACK LOOP DETECTION (Primary - Naming Independent)
 # =============================================================================
@@ -486,7 +485,7 @@ class TestPatternFallback:
         identifier = TopologyBasedLatchIdentifier(case_sensitive=True)
 
         # Patterns are uppercase by default
-        result_lower = identifier.detect_with_reason("dff_x1")
+        _result_lower = identifier.detect_with_reason("dff_x1")
         result_upper = identifier.detect_with_reason("DFF_X1")
 
         # Case-sensitive: lowercase won't match uppercase patterns
@@ -597,7 +596,9 @@ class TestCachingBehavior:
         result2 = identifier.detect_with_reason("MY_CELL")
 
         assert result2.strategy == DetectionStrategy.FEEDBACK_LOOP
-        assert result2.strategy != initial_strategy or initial_strategy == DetectionStrategy.FEEDBACK_LOOP
+        is_different = result2.strategy != initial_strategy
+        was_already_feedback = initial_strategy == DetectionStrategy.FEEDBACK_LOOP
+        assert is_different or was_already_feedback
 
     def test_cache_invalidation_on_explicit_annotation(self) -> None:
         """Cache is invalidated when explicit annotation is added."""

--- a/tests/unit/infrastructure/parsing/test_subcircuit_parser.py
+++ b/tests/unit/infrastructure/parsing/test_subcircuit_parser.py
@@ -184,7 +184,7 @@ class TestParseSubcktLineErrors:
             raw=".SUBCKT",
         )
         parser = SubcircuitParser()
-        with pytest.raises(ValueError, match="Invalid .SUBCKT"):
+        with pytest.raises(ValueError, match=r"Invalid \.SUBCKT"):
             parser.parse_subckt_line(token)
 
     def test_error_no_ports(self) -> None:
@@ -323,7 +323,7 @@ class TestParseEndsLineErrors:
             raw=".ENDS INV",
         )
         parser = SubcircuitParser()
-        with pytest.raises(ValueError, match="without matching .SUBCKT"):
+        with pytest.raises(ValueError, match=r"without matching \.SUBCKT"):
             parser.parse_ends_line(token)
 
     def test_error_ends_wrong_name(self) -> None:

--- a/tests/unit/infrastructure/persistence/test_panel_settings_store.py
+++ b/tests/unit/infrastructure/persistence/test_panel_settings_store.py
@@ -32,6 +32,11 @@ if TYPE_CHECKING:
     from collections.abc import Generator
     from pathlib import Path
 
+    from ink.infrastructure.persistence.panel_settings_store import (
+        PanelSettingsStore as PanelSettingsStoreType,
+    )
+    from ink.presentation.state.panel_state import PanelState as PanelStateType
+
 
 # =============================================================================
 # Module-level Fixtures
@@ -146,7 +151,9 @@ class TestPanelSettingsStoreInit:
         store = PanelSettingsStore()
         assert store is not None
 
-    def test_has_settings_attribute(self, panel_settings_store) -> None:
+    def test_has_settings_attribute(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify store has QSettings instance."""
         assert hasattr(panel_settings_store, "settings")
         assert isinstance(panel_settings_store.settings, QSettings)
@@ -173,11 +180,15 @@ class TestPanelSettingsStoreInit:
 class TestPanelSettingsStoreHasSavedSettings:
     """Test has_saved_settings() method."""
 
-    def test_returns_false_when_no_settings(self, panel_settings_store) -> None:
+    def test_returns_false_when_no_settings(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify returns False when no panel settings exist."""
         assert panel_settings_store.has_saved_settings() is False
 
-    def test_returns_true_when_geometry_exists(self, panel_settings_store) -> None:
+    def test_returns_true_when_geometry_exists(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify returns True when geometry settings exist."""
         from ink.presentation.state.panel_state import PanelState
 
@@ -188,7 +199,9 @@ class TestPanelSettingsStoreHasSavedSettings:
         assert panel_settings_store.has_saved_settings() is True
 
     def test_returns_true_when_panels_exist(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify returns True when panel settings exist."""
         panel_settings_store.save_panel_state(sample_panel_state)
@@ -199,14 +212,18 @@ class TestPanelSettingsStoreSave:
     """Test save_panel_state() method."""
 
     def test_save_panel_state_creates_settings(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify save_panel_state creates settings entries."""
         panel_settings_store.save_panel_state(sample_panel_state)
         assert panel_settings_store.has_saved_settings() is True
 
     def test_save_panel_state_stores_qt_geometry(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify Qt geometry blob is stored."""
         panel_settings_store.save_panel_state(sample_panel_state)
@@ -219,7 +236,9 @@ class TestPanelSettingsStoreSave:
         assert has_window is True
 
     def test_save_panel_state_stores_qt_state(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify Qt state blob is stored."""
         panel_settings_store.save_panel_state(sample_panel_state)
@@ -232,7 +251,9 @@ class TestPanelSettingsStoreSave:
         assert has_state is True
 
     def test_save_panel_state_stores_panel_visibility(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify individual panel visibility is stored."""
         panel_settings_store.save_panel_state(sample_panel_state)
@@ -245,7 +266,9 @@ class TestPanelSettingsStoreSave:
         assert visible is True
 
     def test_save_panel_state_stores_panel_area(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify individual panel area is stored as string."""
         panel_settings_store.save_panel_state(sample_panel_state)
@@ -258,7 +281,9 @@ class TestPanelSettingsStoreSave:
         assert area == "RIGHT"
 
     def test_save_panel_state_stores_panel_geometry(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify panel geometry dict is stored."""
         panel_settings_store.save_panel_state(sample_panel_state)
@@ -275,7 +300,7 @@ class TestPanelSettingsStoreSave:
         assert geometry.get("height") == 400
 
     def test_save_panel_state_stores_floating_state(
-        self, panel_settings_store
+        self, panel_settings_store: "PanelSettingsStoreType"
     ) -> None:
         """Verify floating state is stored."""
         from ink.presentation.state.panel_state import (
@@ -302,7 +327,9 @@ class TestPanelSettingsStoreSave:
 
         assert is_floating is True
 
-    def test_save_panel_state_stores_tab_group(self, panel_settings_store) -> None:
+    def test_save_panel_state_stores_tab_group(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify tab group is stored when present."""
         from ink.presentation.state.panel_state import PanelInfo, PanelState
 
@@ -318,7 +345,9 @@ class TestPanelSettingsStoreSave:
         assert tab_group == "group1"
 
     def test_save_panel_state_calls_sync(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify sync is called after save to force disk write."""
         # Save state and verify settings exist (implies sync worked)
@@ -336,13 +365,17 @@ class TestPanelSettingsStoreSave:
 class TestPanelSettingsStoreLoad:
     """Test load_panel_state() method."""
 
-    def test_load_returns_none_when_no_settings(self, panel_settings_store) -> None:
+    def test_load_returns_none_when_no_settings(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify load returns None when no settings exist."""
         result = panel_settings_store.load_panel_state()
         assert result is None
 
     def test_load_returns_panel_state(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify load returns PanelState when settings exist."""
         from ink.presentation.state.panel_state import PanelState
@@ -354,36 +387,47 @@ class TestPanelSettingsStoreLoad:
         assert isinstance(result, PanelState)
 
     def test_load_restores_qt_geometry(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify Qt geometry blob is restored correctly."""
         panel_settings_store.save_panel_state(sample_panel_state)
         result = panel_settings_store.load_panel_state()
 
+        assert result is not None
         assert result.qt_geometry == sample_panel_state.qt_geometry
 
     def test_load_restores_qt_state(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify Qt state blob is restored correctly."""
         panel_settings_store.save_panel_state(sample_panel_state)
         result = panel_settings_store.load_panel_state()
 
+        assert result is not None
         assert result.qt_state == sample_panel_state.qt_state
 
     def test_load_restores_panel_visibility(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify panel visibility is restored correctly."""
         panel_settings_store.save_panel_state(sample_panel_state)
         result = panel_settings_store.load_panel_state()
 
+        assert result is not None
         # Messages panel was hidden in sample
         assert result.panels["Messages"].visible is False
         assert result.panels["Hierarchy"].visible is True
 
     def test_load_restores_panel_area(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify panel dock area is restored correctly."""
         from ink.presentation.state.panel_state import DockArea
@@ -391,22 +435,28 @@ class TestPanelSettingsStoreLoad:
         panel_settings_store.save_panel_state(sample_panel_state)
         result = panel_settings_store.load_panel_state()
 
+        assert result is not None
         assert result.panels["Hierarchy"].area == DockArea.LEFT
         assert result.panels["Properties"].area == DockArea.RIGHT
         assert result.panels["Messages"].area == DockArea.BOTTOM
 
     def test_load_restores_panel_geometry(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify panel geometry is restored correctly."""
         panel_settings_store.save_panel_state(sample_panel_state)
         result = panel_settings_store.load_panel_state()
 
+        assert result is not None
         hierarchy_geom = result.panels["Hierarchy"].geometry
         assert hierarchy_geom.width == 200
         assert hierarchy_geom.height == 400
 
-    def test_load_restores_floating_state(self, panel_settings_store) -> None:
+    def test_load_restores_floating_state(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify floating state is restored correctly."""
         from ink.presentation.state.panel_state import (
             DockArea,
@@ -424,9 +474,12 @@ class TestPanelSettingsStoreLoad:
         panel_settings_store.save_panel_state(state)
         result = panel_settings_store.load_panel_state()
 
+        assert result is not None
         assert result.panels["FloatingPanel"].is_floating is True
 
-    def test_load_restores_tab_group(self, panel_settings_store) -> None:
+    def test_load_restores_tab_group(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify tab group is restored correctly."""
         from ink.presentation.state.panel_state import PanelInfo, PanelState
 
@@ -436,6 +489,7 @@ class TestPanelSettingsStoreLoad:
         panel_settings_store.save_panel_state(state)
         result = panel_settings_store.load_panel_state()
 
+        assert result is not None
         assert result.panels["TabbedPanel"].tab_group == "group1"
 
 
@@ -443,12 +497,15 @@ class TestPanelSettingsStoreRoundTrip:
     """Test save/load round-trip preserves data integrity."""
 
     def test_roundtrip_preserves_complete_state(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify complete state survives round-trip."""
         panel_settings_store.save_panel_state(sample_panel_state)
         result = panel_settings_store.load_panel_state()
 
+        assert result is not None
         # Check all panels exist
         assert len(result.panels) == len(sample_panel_state.panels)
 
@@ -465,7 +522,7 @@ class TestPanelSettingsStoreRoundTrip:
             assert loaded_info.geometry.y == original_info.geometry.y
 
     def test_roundtrip_across_instances(
-        self, isolated_settings, sample_panel_state
+        self, isolated_settings: Path, sample_panel_state: "PanelStateType"
     ) -> None:
         """Verify state persists across store instances."""
         from ink.infrastructure.persistence.panel_settings_store import (
@@ -487,7 +544,9 @@ class TestPanelSettingsStoreRoundTrip:
 class TestPanelSettingsStoreErrorHandling:
     """Test error handling for corrupted or missing settings."""
 
-    def test_load_handles_invalid_area_name(self, panel_settings_store) -> None:
+    def test_load_handles_invalid_area_name(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify invalid area name defaults to LEFT."""
         from ink.presentation.state.panel_state import DockArea
 
@@ -502,11 +561,14 @@ class TestPanelSettingsStoreErrorHandling:
         panel_settings_store.settings.sync()
 
         result = panel_settings_store.load_panel_state()
+        assert result is not None
 
         # Should default to LEFT
         assert result.panels["BadPanel"].area == DockArea.LEFT
 
-    def test_load_handles_missing_geometry_fields(self, panel_settings_store) -> None:
+    def test_load_handles_missing_geometry_fields(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify missing geometry fields default to zero."""
         # Manually create settings with partial geometry
         panel_settings_store.settings.beginGroup("panels/PartialPanel")
@@ -518,6 +580,7 @@ class TestPanelSettingsStoreErrorHandling:
         panel_settings_store.settings.sync()
 
         result = panel_settings_store.load_panel_state()
+        assert result is not None
 
         geom = result.panels["PartialPanel"].geometry
         assert geom.width == 100
@@ -525,7 +588,9 @@ class TestPanelSettingsStoreErrorHandling:
         assert geom.x == 0  # Default
         assert geom.y == 0  # Default
 
-    def test_load_handles_missing_panel_settings(self, panel_settings_store) -> None:
+    def test_load_handles_missing_panel_settings(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify panels without 'visible' key are skipped."""
         # Create panel with missing required field
         panel_settings_store.settings.beginGroup("panels/IncompletePanel")
@@ -538,7 +603,9 @@ class TestPanelSettingsStoreErrorHandling:
         # Panel should be skipped, not loaded
         assert "IncompletePanel" not in result.panels if result else True
 
-    def test_load_handles_empty_geometry_dict(self, panel_settings_store) -> None:
+    def test_load_handles_empty_geometry_dict(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify empty geometry dict uses defaults."""
         panel_settings_store.settings.beginGroup("panels/EmptyGeom")
         panel_settings_store.settings.setValue("visible", True)
@@ -549,6 +616,7 @@ class TestPanelSettingsStoreErrorHandling:
         panel_settings_store.settings.sync()
 
         result = panel_settings_store.load_panel_state()
+        assert result is not None
 
         geom = result.panels["EmptyGeom"].geometry
         assert geom.width == 0
@@ -561,7 +629,9 @@ class TestPanelSettingsStoreClear:
     """Test clear_panel_state() method."""
 
     def test_clear_removes_geometry_settings(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify clear removes geometry group settings."""
         panel_settings_store.save_panel_state(sample_panel_state)
@@ -575,7 +645,9 @@ class TestPanelSettingsStoreClear:
         assert has_window is False
 
     def test_clear_removes_panel_settings(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify clear removes panels group settings."""
         panel_settings_store.save_panel_state(sample_panel_state)
@@ -589,7 +661,9 @@ class TestPanelSettingsStoreClear:
         assert len(child_groups) == 0
 
     def test_clear_makes_has_saved_settings_false(
-        self, panel_settings_store, sample_panel_state
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
     ) -> None:
         """Verify has_saved_settings returns False after clear."""
         panel_settings_store.save_panel_state(sample_panel_state)
@@ -598,7 +672,10 @@ class TestPanelSettingsStoreClear:
         assert panel_settings_store.has_saved_settings() is False
 
     def test_clear_calls_sync(
-        self, panel_settings_store, sample_panel_state, isolated_settings
+        self,
+        panel_settings_store: "PanelSettingsStoreType",
+        sample_panel_state: "PanelStateType",
+        isolated_settings: Path,
     ) -> None:
         """Verify sync is called after clear to persist changes."""
         from ink.infrastructure.persistence.panel_settings_store import (
@@ -616,7 +693,9 @@ class TestPanelSettingsStoreClear:
 class TestPanelSettingsStoreFloatingPanelGeometry:
     """Test floating panel geometry position persistence."""
 
-    def test_floating_panel_position_preserved(self, panel_settings_store) -> None:
+    def test_floating_panel_position_preserved(
+        self, panel_settings_store: "PanelSettingsStoreType"
+    ) -> None:
         """Verify floating panel x,y position is preserved."""
         from ink.presentation.state.panel_state import (
             DockArea,
@@ -636,6 +715,7 @@ class TestPanelSettingsStoreFloatingPanelGeometry:
 
         panel_settings_store.save_panel_state(state)
         result = panel_settings_store.load_panel_state()
+        assert result is not None
 
         geom = result.panels["FloatingPanel"].geometry
         assert geom.x == 150

--- a/tests/unit/presentation/canvas/test_pin_item.py
+++ b/tests/unit/presentation/canvas/test_pin_item.py
@@ -1,0 +1,891 @@
+"""Unit tests for PinItem graphics widget.
+
+Tests verify the PinItem implementation meets all requirements from spec E02-F01-T02:
+- PinItem instantiation with Pin domain entity and parent CellItem
+- Rendering of pins as small circles on cell edges
+- Pin name labels displayed adjacent to pins
+- Direction arrows for input/output/inout pins
+- Connection point calculation in scene coordinates
+- Detail level support (MINIMAL/BASIC/FULL)
+- Parent-child coordinate transformations
+
+TDD Approach:
+- RED phase: These tests will fail initially as PinItem doesn't exist yet
+- GREEN phase: Implement PinItem to pass all tests
+- REFACTOR phase: Clean up and optimize implementation
+
+Architecture Notes:
+- PinItem is a QGraphicsItem subclass in the presentation layer
+- It is a child of CellItem for coordinate inheritance
+- It wraps a Pin domain entity from the domain layer
+- No domain logic in PinItem - only rendering and interaction
+
+See Also:
+- Spec E02-F01-T02 for detailed requirements
+- src/ink/domain/model/pin.py for Pin domain entity
+- src/ink/presentation/canvas/cell_item.py for parent CellItem
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from PySide6.QtCore import QPointF, QRectF
+from PySide6.QtWidgets import (
+    QGraphicsItem,
+    QGraphicsScene,
+    QGraphicsView,
+)
+
+from ink.domain.model.cell import Cell
+from ink.domain.model.pin import Pin
+from ink.domain.value_objects.identifiers import CellId, NetId, PinId
+from ink.domain.value_objects.pin_direction import PinDirection
+from ink.presentation.canvas.cell_item import CellItem
+from ink.presentation.canvas.detail_level import DetailLevel
+from ink.presentation.canvas.pin_item import PinItem
+
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def input_pin() -> Pin:
+    """Create an input pin for testing.
+
+    Returns:
+        Pin: An input pin instance with a connected net.
+    """
+    return Pin(
+        id=PinId("U1.A"),
+        name="A",
+        direction=PinDirection.INPUT,
+        net_id=NetId("net_001"),
+    )
+
+
+@pytest.fixture
+def output_pin() -> Pin:
+    """Create an output pin for testing.
+
+    Returns:
+        Pin: An output pin instance with a connected net.
+    """
+    return Pin(
+        id=PinId("U1.Y"),
+        name="Y",
+        direction=PinDirection.OUTPUT,
+        net_id=NetId("net_002"),
+    )
+
+
+@pytest.fixture
+def inout_pin() -> Pin:
+    """Create an inout (bidirectional) pin for testing.
+
+    Returns:
+        Pin: An inout pin instance with a connected net.
+    """
+    return Pin(
+        id=PinId("U1.IO"),
+        name="IO",
+        direction=PinDirection.INOUT,
+        net_id=NetId("net_003"),
+    )
+
+
+@pytest.fixture
+def long_name_pin() -> Pin:
+    """Create a pin with a long name for label testing.
+
+    Returns:
+        Pin: A pin with a long name for text elision testing.
+    """
+    return Pin(
+        id=PinId("U1.DATA_IN_FROM_BUFFER"),
+        name="DATA_IN_FROM_BUFFER",
+        direction=PinDirection.INPUT,
+        net_id=NetId("net_004"),
+    )
+
+
+@pytest.fixture
+def floating_pin() -> Pin:
+    """Create a floating (unconnected) pin for testing.
+
+    Returns:
+        Pin: A pin without a connected net.
+    """
+    return Pin(
+        id=PinId("U1.NC"),
+        name="NC",
+        direction=PinDirection.INPUT,
+        net_id=None,
+    )
+
+
+@pytest.fixture
+def parent_cell() -> Cell:
+    """Create a parent cell for testing pin items.
+
+    Returns:
+        Cell: A simple AND gate cell instance.
+    """
+    return Cell(
+        id=CellId("U1"),
+        name="U1",
+        cell_type="AND2_X1",
+        pin_ids=[PinId("U1.A"), PinId("U1.B"), PinId("U1.Y")],
+        is_sequential=False,
+    )
+
+
+@pytest.fixture
+def parent_cell_item(parent_cell: Cell) -> CellItem:
+    """Create a parent CellItem for testing pin items.
+
+    Args:
+        parent_cell: Cell domain entity.
+
+    Returns:
+        CellItem: A CellItem instance to use as parent.
+    """
+    return CellItem(parent_cell)
+
+
+@pytest.fixture
+def graphics_scene(qtbot: QtBot) -> QGraphicsScene:
+    """Create a QGraphicsScene for testing PinItem in context.
+
+    Args:
+        qtbot: pytest-qt fixture for Qt widget management.
+
+    Returns:
+        QGraphicsScene: Scene for adding graphics items.
+    """
+    return QGraphicsScene()
+
+
+@pytest.fixture
+def graphics_view(qtbot: QtBot, graphics_scene: QGraphicsScene) -> QGraphicsView:
+    """Create a QGraphicsView for testing PinItem rendering.
+
+    Args:
+        qtbot: pytest-qt fixture for Qt widget management.
+        graphics_scene: Scene containing items to display.
+
+    Returns:
+        QGraphicsView: View for rendering the scene.
+    """
+    view = QGraphicsView(graphics_scene)
+    qtbot.addWidget(view)
+    return view
+
+
+# =============================================================================
+# PinItem Creation Tests
+# =============================================================================
+
+
+class TestPinItemCreation:
+    """Tests for PinItem instantiation and basic properties."""
+
+    def test_pin_item_can_be_created(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that PinItem can be instantiated with a Pin entity and parent.
+
+        Verifies:
+        - No exceptions during construction
+        - Returns a valid object instance
+        """
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        assert pin_item is not None
+
+    def test_pin_item_is_qgraphics_item_subclass(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that PinItem inherits from QGraphicsItem.
+
+        QGraphicsItem is required for use in QGraphicsScene.
+        """
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        assert isinstance(pin_item, QGraphicsItem)
+
+    def test_pin_item_stores_pin_reference(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that PinItem stores reference to the domain Pin entity.
+
+        The domain pin is needed for property queries and rendering.
+        """
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        retrieved_pin = pin_item.get_pin()
+
+        assert retrieved_pin is input_pin
+        assert retrieved_pin.name == "A"
+        assert retrieved_pin.direction == PinDirection.INPUT
+
+    def test_pin_item_has_parent_cell_item(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that PinItem is a child of the parent CellItem.
+
+        Parent-child relationship is used for coordinate inheritance.
+        """
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        assert pin_item.parentItem() is parent_cell_item
+
+    def test_pin_item_default_detail_level_is_full(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that PinItem defaults to FULL detail level.
+
+        FULL detail shows pin dot + name + arrow.
+        """
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        # The default should be FULL detail level
+        # This tests internal state - implementation may vary
+        assert pin_item.isVisible()
+
+
+# =============================================================================
+# PinItem Constants Tests
+# =============================================================================
+
+
+class TestPinItemConstants:
+    """Tests for PinItem class constants."""
+
+    def test_pin_radius_constant(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that PIN_RADIUS is defined as 3.0 pixels."""
+        assert PinItem.PIN_RADIUS == 3.0
+
+    def test_arrow_size_constant(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that ARROW_SIZE is defined as 8.0 pixels."""
+        assert PinItem.ARROW_SIZE == 8.0
+
+    def test_label_offset_constant(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that LABEL_OFFSET is defined as 5.0 pixels."""
+        assert PinItem.LABEL_OFFSET == 5.0
+
+
+# =============================================================================
+# Bounding Rect Tests
+# =============================================================================
+
+
+class TestPinItemBoundingRect:
+    """Tests for PinItem.boundingRect() method."""
+
+    def test_bounding_rect_returns_qrectf(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that boundingRect returns a QRectF object."""
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        bounding_rect = pin_item.boundingRect()
+
+        assert isinstance(bounding_rect, QRectF)
+
+    def test_bounding_rect_at_minimal_level_is_empty(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that boundingRect is empty at MINIMAL detail level.
+
+        At MINIMAL level, pins are hidden and don't need bounds.
+        """
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.MINIMAL)
+
+        bounding_rect = pin_item.boundingRect()
+
+        assert bounding_rect.isEmpty()
+
+    def test_bounding_rect_at_basic_level_is_small(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that boundingRect at BASIC level only covers pin circle.
+
+        At BASIC level, only the dot is shown (no label, no arrow).
+        """
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.BASIC)
+
+        bounding_rect = pin_item.boundingRect()
+
+        # Should be approximately 2 * PIN_RADIUS = 6 pixels
+        assert bounding_rect.width() <= PinItem.PIN_RADIUS * 2 + 2
+        assert bounding_rect.height() <= PinItem.PIN_RADIUS * 2 + 2
+
+    def test_bounding_rect_at_full_level_includes_label_and_arrow(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that boundingRect at FULL level includes label and arrow.
+
+        At FULL level, the bounding rect should be larger to include
+        the pin name label and direction arrow.
+        """
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.FULL)
+
+        bounding_rect = pin_item.boundingRect()
+
+        # Should be larger than just the pin circle
+        assert bounding_rect.width() > PinItem.PIN_RADIUS * 2
+        assert not bounding_rect.isEmpty()
+
+    def test_long_name_pin_has_larger_bounding_rect(
+        self, qtbot: QtBot, long_name_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that pins with long names have larger bounding rect."""
+        pin_item = PinItem(long_name_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.FULL)
+
+        bounding_rect = pin_item.boundingRect()
+
+        # Long name should result in wider bounding rect
+        assert bounding_rect.width() > 50  # Approximate label width
+
+
+# =============================================================================
+# Detail Level Tests
+# =============================================================================
+
+
+class TestPinItemDetailLevel:
+    """Tests for PinItem detail level management."""
+
+    def test_set_detail_level_to_minimal_hides_pin(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that setting MINIMAL detail level hides the pin."""
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        pin_item.set_detail_level(DetailLevel.MINIMAL)
+
+        assert not pin_item.isVisible()
+
+    def test_set_detail_level_to_basic_shows_pin(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that setting BASIC detail level shows the pin."""
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.MINIMAL)  # First hide it
+
+        pin_item.set_detail_level(DetailLevel.BASIC)
+
+        assert pin_item.isVisible()
+
+    def test_set_detail_level_to_full_shows_pin(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that setting FULL detail level shows the pin."""
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.MINIMAL)  # First hide it
+
+        pin_item.set_detail_level(DetailLevel.FULL)
+
+        assert pin_item.isVisible()
+
+    def test_detail_level_change_triggers_update(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+    ) -> None:
+        """Test that changing detail level triggers a visual update."""
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        # Changing level should not raise exceptions
+        pin_item.set_detail_level(DetailLevel.BASIC)
+        pin_item.set_detail_level(DetailLevel.FULL)
+        pin_item.set_detail_level(DetailLevel.MINIMAL)
+
+        # If we get here without exception, the update worked
+        assert True
+
+
+# =============================================================================
+# Connection Point Tests
+# =============================================================================
+
+
+class TestPinItemConnectionPoint:
+    """Tests for PinItem.get_connection_point() method.
+
+    The connection point is critical for net routing - it must return
+    accurate scene coordinates where nets should connect to the pin.
+    """
+
+    def test_connection_point_returns_qpointf(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that get_connection_point returns a QPointF."""
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        connection_point = pin_item.get_connection_point()
+
+        assert isinstance(connection_point, QPointF)
+
+    def test_connection_point_at_origin_when_no_position_set(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+    ) -> None:
+        """Test connection point when pin is at origin.
+
+        When both cell and pin are at origin, connection point should be (0, 0).
+        """
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+        # Pin is at (0, 0) relative to parent, parent is at (0, 0)
+
+        connection_point = pin_item.get_connection_point()
+
+        assert connection_point.x() == pytest.approx(0.0, abs=0.1)
+        assert connection_point.y() == pytest.approx(0.0, abs=0.1)
+
+    def test_connection_point_accounts_for_pin_position(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+    ) -> None:
+        """Test connection point when pin has offset from parent.
+
+        Pin positioned at (10, 20) relative to parent at origin
+        should return connection point at (10, 20) in scene coords.
+        """
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.setPos(10.0, 20.0)
+
+        connection_point = pin_item.get_connection_point()
+
+        assert connection_point.x() == pytest.approx(10.0, abs=0.1)
+        assert connection_point.y() == pytest.approx(20.0, abs=0.1)
+
+    def test_connection_point_accounts_for_parent_position(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+    ) -> None:
+        """Test connection point when parent cell has position.
+
+        Parent at (100, 200), pin at (10, 20) relative to parent
+        should return connection point at (110, 220) in scene coords.
+        """
+        graphics_scene.addItem(parent_cell_item)
+        parent_cell_item.setPos(100.0, 200.0)
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.setPos(10.0, 20.0)
+
+        connection_point = pin_item.get_connection_point()
+
+        assert connection_point.x() == pytest.approx(110.0, abs=0.1)
+        assert connection_point.y() == pytest.approx(220.0, abs=0.1)
+
+    def test_connection_point_changes_with_parent_movement(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+    ) -> None:
+        """Test that connection point updates when parent moves.
+
+        Moving the parent cell should update the pin's connection point.
+        """
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.setPos(10.0, 20.0)
+
+        # Initial position
+        parent_cell_item.setPos(0.0, 0.0)
+        point1 = pin_item.get_connection_point()
+
+        # Move parent
+        parent_cell_item.setPos(50.0, 100.0)
+        point2 = pin_item.get_connection_point()
+
+        # Connection point should have moved by (50, 100)
+        assert point2.x() - point1.x() == pytest.approx(50.0, abs=0.1)
+        assert point2.y() - point1.y() == pytest.approx(100.0, abs=0.1)
+
+
+# =============================================================================
+# Pin Direction Arrow Tests
+# =============================================================================
+
+
+class TestPinItemDirectionArrows:
+    """Tests for pin direction arrow rendering."""
+
+    def test_input_pin_direction_is_stored(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that input pin direction is correctly accessible."""
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        assert pin_item.get_pin().direction == PinDirection.INPUT
+
+    def test_output_pin_direction_is_stored(
+        self, qtbot: QtBot, output_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that output pin direction is correctly accessible."""
+        pin_item = PinItem(output_pin, parent_cell_item)
+
+        assert pin_item.get_pin().direction == PinDirection.OUTPUT
+
+    def test_inout_pin_direction_is_stored(
+        self, qtbot: QtBot, inout_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that inout pin direction is correctly accessible."""
+        pin_item = PinItem(inout_pin, parent_cell_item)
+
+        assert pin_item.get_pin().direction == PinDirection.INOUT
+
+
+# =============================================================================
+# Paint Method Tests
+# =============================================================================
+
+
+class TestPinItemPaint:
+    """Tests for PinItem.paint() method.
+
+    Note: These tests verify that paint() can be called without errors.
+    Actual visual verification would require snapshot testing.
+    """
+
+    def test_paint_method_exists(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that paint method is implemented."""
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        assert hasattr(pin_item, "paint")
+        assert callable(pin_item.paint)
+
+    def test_paint_can_be_called_without_error(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+        graphics_view: QGraphicsView,
+    ) -> None:
+        """Test that paint executes without raising exceptions."""
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.setPos(0.0, 20.0)
+
+        graphics_view.show()
+        qtbot.waitExposed(graphics_view)
+
+        # If we get here without exception, paint worked
+        assert True
+
+    def test_paint_at_minimal_level_does_not_crash(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+        graphics_view: QGraphicsView,
+    ) -> None:
+        """Test that paint at MINIMAL level works without error."""
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.MINIMAL)
+
+        graphics_view.show()
+        qtbot.waitExposed(graphics_view)
+
+        assert True
+
+    def test_paint_at_basic_level_does_not_crash(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+        graphics_view: QGraphicsView,
+    ) -> None:
+        """Test that paint at BASIC level works without error."""
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.BASIC)
+
+        graphics_view.show()
+        qtbot.waitExposed(graphics_view)
+
+        assert True
+
+    def test_paint_at_full_level_does_not_crash(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+        graphics_view: QGraphicsView,
+    ) -> None:
+        """Test that paint at FULL level works without error."""
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.FULL)
+
+        graphics_view.show()
+        qtbot.waitExposed(graphics_view)
+
+        assert True
+
+    def test_paint_all_pin_directions_without_error(
+        self,
+        qtbot: QtBot,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+        graphics_view: QGraphicsView,
+    ) -> None:
+        """Test that painting all pin direction types works without error."""
+        graphics_scene.addItem(parent_cell_item)
+
+        # Create pins directly to reduce fixture dependencies
+        input_pin = Pin(
+            id=PinId("U1.A"), name="A",
+            direction=PinDirection.INPUT, net_id=NetId("net_001")
+        )
+        output_pin = Pin(
+            id=PinId("U1.Y"), name="Y",
+            direction=PinDirection.OUTPUT, net_id=NetId("net_002")
+        )
+        inout_pin = Pin(
+            id=PinId("U1.IO"), name="IO",
+            direction=PinDirection.INOUT, net_id=NetId("net_003")
+        )
+
+        input_item = PinItem(input_pin, parent_cell_item)
+        input_item.setPos(0.0, 20.0)
+
+        output_item = PinItem(output_pin, parent_cell_item)
+        output_item.setPos(CellItem.DEFAULT_WIDTH, 20.0)
+
+        inout_item = PinItem(inout_pin, parent_cell_item)
+        inout_item.setPos(CellItem.DEFAULT_WIDTH, 40.0)
+
+        graphics_view.show()
+        qtbot.waitExposed(graphics_view)
+
+        assert True
+
+
+# =============================================================================
+# Scene Integration Tests
+# =============================================================================
+
+
+class TestPinItemSceneIntegration:
+    """Integration tests for PinItem within QGraphicsScene."""
+
+    def test_pin_item_appears_in_scene_items(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+    ) -> None:
+        """Test that PinItem appears in scene items list."""
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        # PinItem is a child of CellItem, so it should be in scene
+        all_items = graphics_scene.items()
+
+        assert pin_item in all_items
+
+    def test_multiple_pins_on_cell(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        output_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+    ) -> None:
+        """Test that multiple pins can be added to a single cell."""
+        graphics_scene.addItem(parent_cell_item)
+
+        pin1 = PinItem(input_pin, parent_cell_item)
+        pin1.setPos(0.0, 20.0)
+
+        pin2 = PinItem(output_pin, parent_cell_item)
+        pin2.setPos(CellItem.DEFAULT_WIDTH, 20.0)
+
+        # Both pins should be in scene
+        all_items = graphics_scene.items()
+        assert pin1 in all_items
+        assert pin2 in all_items
+
+    def test_pin_inherits_parent_visibility(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+    ) -> None:
+        """Test that pin visibility follows parent cell visibility."""
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+
+        # Hide parent
+        parent_cell_item.setVisible(False)
+
+        # Pin should effectively be hidden (isVisible checks parent chain)
+        # Note: Qt's isVisible() checks the entire parent chain
+        assert not pin_item.isVisible() or not parent_cell_item.isVisible()
+
+
+# =============================================================================
+# Edge Cases and Error Handling Tests
+# =============================================================================
+
+
+class TestPinItemEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_floating_pin_renders_correctly(
+        self,
+        qtbot: QtBot,
+        floating_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+        graphics_view: QGraphicsView,
+    ) -> None:
+        """Test that floating (unconnected) pins render without error."""
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(floating_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.FULL)
+
+        graphics_view.show()
+        qtbot.waitExposed(graphics_view)
+
+        assert pin_item.get_pin().net_id is None
+        assert True  # No crash
+
+    def test_empty_pin_name_renders_correctly(
+        self,
+        qtbot: QtBot,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+        graphics_view: QGraphicsView,
+    ) -> None:
+        """Test that pins with empty names render without error."""
+        empty_name_pin = Pin(
+            id=PinId("U1."),
+            name="",
+            direction=PinDirection.INPUT,
+            net_id=None,
+        )
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(empty_name_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.FULL)
+
+        graphics_view.show()
+        qtbot.waitExposed(graphics_view)
+
+        assert True  # No crash
+
+    def test_detail_level_same_value_no_update(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+    ) -> None:
+        """Test that setting same detail level doesn't cause unnecessary updates."""
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.set_detail_level(DetailLevel.FULL)
+
+        # Setting the same level again should not cause issues
+        pin_item.set_detail_level(DetailLevel.FULL)
+
+        # If we get here without exception, it worked
+        assert True
+
+
+# =============================================================================
+# Performance-Related Tests
+# =============================================================================
+
+
+class TestPinItemPerformance:
+    """Tests related to performance characteristics."""
+
+    def test_pin_item_creation_is_fast(
+        self, qtbot: QtBot, input_pin: Pin, parent_cell_item: CellItem
+    ) -> None:
+        """Test that creating many pin items is reasonably fast."""
+        import time
+
+        start = time.perf_counter()
+
+        for _ in range(100):
+            pin = Pin(
+                id=PinId(f"U1.P{_}"),
+                name=f"P{_}",
+                direction=PinDirection.INPUT,
+                net_id=None,
+            )
+            PinItem(pin, parent_cell_item)
+
+        elapsed = time.perf_counter() - start
+
+        # Should create 100 items in less than 0.5 seconds
+        assert elapsed < 0.5
+
+    def test_connection_point_calculation_is_fast(
+        self,
+        qtbot: QtBot,
+        input_pin: Pin,
+        parent_cell_item: CellItem,
+        graphics_scene: QGraphicsScene,
+    ) -> None:
+        """Test that connection point calculation is fast."""
+        import time
+
+        graphics_scene.addItem(parent_cell_item)
+        pin_item = PinItem(input_pin, parent_cell_item)
+        pin_item.setPos(10.0, 20.0)
+
+        start = time.perf_counter()
+
+        for _ in range(1000):
+            pin_item.get_connection_point()
+
+        elapsed = time.perf_counter() - start
+
+        # Should calculate 1000 points in less than 0.1 seconds
+        assert elapsed < 0.1

--- a/tests/unit/presentation/dialogs/test_net_classification_dialog.py
+++ b/tests/unit/presentation/dialogs/test_net_classification_dialog.py
@@ -19,6 +19,8 @@ See Also:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from PySide6.QtWidgets import (
     QCheckBox,
     QDialogButtonBox,
@@ -30,11 +32,14 @@ from ink.infrastructure.config.net_classification_config import (
     NetClassificationConfig,
 )
 
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
+
 
 class TestNetClassificationDialogCreation:
     """Tests for dialog instantiation and basic properties."""
 
-    def test_dialog_creates_successfully(self, qtbot) -> None:
+    def test_dialog_creates_successfully(self, qtbot: "QtBot") -> None:
         """Test that dialog can be created with a config."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -46,7 +51,7 @@ class TestNetClassificationDialogCreation:
 
         assert dialog is not None
 
-    def test_dialog_has_correct_title(self, qtbot) -> None:
+    def test_dialog_has_correct_title(self, qtbot: "QtBot") -> None:
         """Test that dialog has the expected window title."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -58,7 +63,7 @@ class TestNetClassificationDialogCreation:
 
         assert dialog.windowTitle() == "Net Classification Settings"
 
-    def test_dialog_has_minimum_size(self, qtbot) -> None:
+    def test_dialog_has_minimum_size(self, qtbot: "QtBot") -> None:
         """Test that dialog has a reasonable minimum size."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -75,7 +80,7 @@ class TestNetClassificationDialogCreation:
 class TestNetClassificationDialogUIComponents:
     """Tests for UI widget structure."""
 
-    def test_dialog_has_tab_widget(self, qtbot) -> None:
+    def test_dialog_has_tab_widget(self, qtbot: "QtBot") -> None:
         """Test that dialog contains a tab widget for Power/Ground."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -88,7 +93,7 @@ class TestNetClassificationDialogUIComponents:
         tab_widget = dialog.findChild(QTabWidget)
         assert tab_widget is not None
 
-    def test_dialog_has_power_tab(self, qtbot) -> None:
+    def test_dialog_has_power_tab(self, qtbot: "QtBot") -> None:
         """Test that dialog has a Power Nets tab."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -110,7 +115,7 @@ class TestNetClassificationDialogUIComponents:
 
         assert power_tab_index >= 0, "Power Nets tab not found"
 
-    def test_dialog_has_ground_tab(self, qtbot) -> None:
+    def test_dialog_has_ground_tab(self, qtbot: "QtBot") -> None:
         """Test that dialog has a Ground Nets tab."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -132,7 +137,7 @@ class TestNetClassificationDialogUIComponents:
 
         assert ground_tab_index >= 0, "Ground Nets tab not found"
 
-    def test_dialog_has_override_checkbox(self, qtbot) -> None:
+    def test_dialog_has_override_checkbox(self, qtbot: "QtBot") -> None:
         """Test that dialog has an override defaults checkbox."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -145,7 +150,7 @@ class TestNetClassificationDialogUIComponents:
         checkbox = dialog.findChild(QCheckBox)
         assert checkbox is not None
 
-    def test_dialog_has_ok_cancel_buttons(self, qtbot) -> None:
+    def test_dialog_has_ok_cancel_buttons(self, qtbot: "QtBot") -> None:
         """Test that dialog has OK and Cancel buttons."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -164,7 +169,7 @@ class TestNetClassificationDialogUIComponents:
         assert ok_button is not None
         assert cancel_button is not None
 
-    def test_dialog_has_list_widgets_for_names(self, qtbot) -> None:
+    def test_dialog_has_list_widgets_for_names(self, qtbot: "QtBot") -> None:
         """Test that dialog has list widgets for net names."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -183,7 +188,7 @@ class TestNetClassificationDialogUIComponents:
 class TestNetClassificationDialogConfigDisplay:
     """Tests that dialog displays current configuration correctly."""
 
-    def test_dialog_displays_power_names(self, qtbot) -> None:
+    def test_dialog_displays_power_names(self, qtbot: "QtBot") -> None:
         """Test that power names from config are shown in the list."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -201,7 +206,7 @@ class TestNetClassificationDialogConfigDisplay:
         assert "DVDD" in power_names
         assert "VDD_CORE" in power_names
 
-    def test_dialog_displays_power_patterns(self, qtbot) -> None:
+    def test_dialog_displays_power_patterns(self, qtbot: "QtBot") -> None:
         """Test that power patterns from config are shown in the list."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -217,7 +222,7 @@ class TestNetClassificationDialogConfigDisplay:
         assert "^PWR_.*$" in power_patterns
         assert "^VDDQ[0-9]*$" in power_patterns
 
-    def test_dialog_displays_ground_names(self, qtbot) -> None:
+    def test_dialog_displays_ground_names(self, qtbot: "QtBot") -> None:
         """Test that ground names from config are shown in the list."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -233,7 +238,7 @@ class TestNetClassificationDialogConfigDisplay:
         assert "AVSS" in ground_names
         assert "DVSS" in ground_names
 
-    def test_dialog_displays_ground_patterns(self, qtbot) -> None:
+    def test_dialog_displays_ground_patterns(self, qtbot: "QtBot") -> None:
         """Test that ground patterns from config are shown in the list."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -248,7 +253,7 @@ class TestNetClassificationDialogConfigDisplay:
         ground_patterns = dialog.get_ground_patterns()
         assert "^GND_.*$" in ground_patterns
 
-    def test_dialog_displays_override_defaults(self, qtbot) -> None:
+    def test_dialog_displays_override_defaults(self, qtbot: "QtBot") -> None:
         """Test that override defaults checkbox reflects config."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -266,7 +271,7 @@ class TestNetClassificationDialogConfigDisplay:
 class TestNetClassificationDialogGetConfig:
     """Tests for retrieving the edited configuration."""
 
-    def test_get_config_returns_config_object(self, qtbot) -> None:
+    def test_get_config_returns_config_object(self, qtbot: "QtBot") -> None:
         """Test that get_config returns a NetClassificationConfig."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -279,7 +284,7 @@ class TestNetClassificationDialogGetConfig:
         result = dialog.get_config()
         assert isinstance(result, NetClassificationConfig)
 
-    def test_get_config_preserves_power_names(self, qtbot) -> None:
+    def test_get_config_preserves_power_names(self, qtbot: "QtBot") -> None:
         """Test that get_config preserves power names."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -295,7 +300,7 @@ class TestNetClassificationDialogGetConfig:
         assert "AVDD" in result.power_names
         assert "DVDD" in result.power_names
 
-    def test_get_config_preserves_override_defaults(self, qtbot) -> None:
+    def test_get_config_preserves_override_defaults(self, qtbot: "QtBot") -> None:
         """Test that get_config preserves override_defaults flag."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -308,7 +313,7 @@ class TestNetClassificationDialogGetConfig:
         result = dialog.get_config()
         assert result.override_defaults is True
 
-    def test_get_config_reflects_checkbox_change(self, qtbot) -> None:
+    def test_get_config_reflects_checkbox_change(self, qtbot: "QtBot") -> None:
         """Test that toggling the checkbox is reflected in get_config."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -330,7 +335,7 @@ class TestNetClassificationDialogGetConfig:
 class TestNetClassificationDialogEmptyConfig:
     """Tests for dialog with empty configuration."""
 
-    def test_dialog_handles_empty_config(self, qtbot) -> None:
+    def test_dialog_handles_empty_config(self, qtbot: "QtBot") -> None:
         """Test that dialog works with empty config."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,
@@ -345,7 +350,7 @@ class TestNetClassificationDialogEmptyConfig:
         assert len(dialog.get_ground_names()) == 0
         assert len(dialog.get_ground_patterns()) == 0
 
-    def test_empty_config_override_false(self, qtbot) -> None:
+    def test_empty_config_override_false(self, qtbot: "QtBot") -> None:
         """Test that empty config has override_defaults=False."""
         from ink.presentation.dialogs.net_classification_dialog import (
             NetClassificationDialog,

--- a/tests/unit/presentation/dialogs/test_net_classification_dialog.py
+++ b/tests/unit/presentation/dialogs/test_net_classification_dialog.py
@@ -19,13 +19,10 @@ See Also:
 
 from __future__ import annotations
 
-import pytest
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QCheckBox,
     QDialogButtonBox,
     QListWidget,
-    QPushButton,
     QTabWidget,
 )
 

--- a/tests/unit/presentation/test_main_window.py
+++ b/tests/unit/presentation/test_main_window.py
@@ -438,6 +438,7 @@ class TestViewControlActions:
         qtbot.addWidget(window)
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         actions = toolbar.actions()
         action_texts = [a.text() for a in actions if not a.isSeparator()]
 
@@ -464,6 +465,7 @@ class TestViewControlActions:
         qtbot.addWidget(window)
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         actions = {a.text(): a for a in toolbar.actions() if not a.isSeparator()}
 
         zoom_in = actions["Zoom In"]
@@ -485,6 +487,7 @@ class TestViewControlActions:
         qtbot.addWidget(window)
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         actions = {a.text(): a for a in toolbar.actions() if not a.isSeparator()}
 
         # Tooltips should contain shortcut information
@@ -509,6 +512,7 @@ class TestViewControlActions:
         window.schematic_canvas = mock_canvas
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         actions = {a.text(): a for a in toolbar.actions() if not a.isSeparator()}
 
         actions["Zoom In"].trigger()
@@ -531,6 +535,7 @@ class TestViewControlActions:
         window.schematic_canvas = mock_canvas
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         actions = {a.text(): a for a in toolbar.actions() if not a.isSeparator()}
 
         actions["Zoom Out"].trigger()
@@ -553,6 +558,7 @@ class TestViewControlActions:
         window.schematic_canvas = mock_canvas
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         actions = {a.text(): a for a in toolbar.actions() if not a.isSeparator()}
 
         actions["Fit View"].trigger()
@@ -572,6 +578,7 @@ class TestViewControlActions:
         window.schematic_canvas = None  # type: ignore[assignment]
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         actions = {a.text(): a for a in toolbar.actions() if not a.isSeparator()}
 
         # Should not raise exception
@@ -599,6 +606,7 @@ class TestViewControlActions:
         window.schematic_canvas = mock_canvas
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         actions = {a.text(): a for a in toolbar.actions() if not a.isSeparator()}
 
         # Should not raise exception - graceful degradation
@@ -618,6 +626,7 @@ class TestViewControlActions:
         qtbot.addWidget(window)
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         actions = {a.text(): a for a in toolbar.actions() if not a.isSeparator()}
 
         assert actions["Zoom In"].isEnabled()
@@ -665,6 +674,7 @@ class TestViewControlActions:
         qtbot.addWidget(window)
 
         toolbar = window.findChild(QToolBar, "MainToolBar")
+        assert toolbar is not None
         actions = toolbar.actions()
 
         # Find Fit View action (last in view group)

--- a/tests/unit/presentation/test_main_window_file_status.py
+++ b/tests/unit/presentation/test_main_window_file_status.py
@@ -444,7 +444,7 @@ class TestUpdateViewCountsBehavior:
 
         After file is closed, expansion_state may be set to None.
         """
-        main_window.expansion_state = None
+        setattr(main_window, "expansion_state", None)
 
         main_window._update_view_counts()
         assert main_window.object_count_label.text() == "Cells: 0 / Nets: 0"
@@ -460,7 +460,7 @@ class TestUpdateViewCountsBehavior:
         mock_state = Mock()
         mock_state.visible_cells = {"cell1", "cell2", "cell3", "cell4", "cell5"}
         mock_state.visible_nets = {"net1", "net2", "net3"}
-        main_window.expansion_state = mock_state
+        setattr(main_window, "expansion_state", mock_state)
 
         main_window._update_view_counts()
         assert main_window.object_count_label.text() == "Cells: 5 / Nets: 3"
@@ -475,7 +475,7 @@ class TestUpdateViewCountsBehavior:
         mock_state = Mock()
         mock_state.visible_cells = set()
         mock_state.visible_nets = set()
-        main_window.expansion_state = mock_state
+        setattr(main_window, "expansion_state", mock_state)
 
         main_window._update_view_counts()
         assert main_window.object_count_label.text() == "Cells: 0 / Nets: 0"
@@ -490,7 +490,7 @@ class TestUpdateViewCountsBehavior:
         mock_state = Mock()
         mock_state.visible_cells = {f"cell{i}" for i in range(5000)}
         mock_state.visible_nets = {f"net{i}" for i in range(7500)}
-        main_window.expansion_state = mock_state
+        setattr(main_window, "expansion_state", mock_state)
 
         main_window._update_view_counts()
         assert main_window.object_count_label.text() == "Cells: 5000 / Nets: 7500"

--- a/tests/unit/presentation/test_main_window_selection_status.py
+++ b/tests/unit/presentation/test_main_window_selection_status.py
@@ -258,7 +258,7 @@ class TestSelectionServiceIntegration:
             selection_changed = Signal(list)
 
         mock_service = MockSelectionService()
-        main_window.selection_service = mock_service
+        setattr(main_window, "selection_service", mock_service)
 
         # Reconnect signals with the mock service
         main_window._connect_status_signals()
@@ -287,7 +287,7 @@ class TestSelectionServiceIntegration:
             selection_changed = Signal(list)
 
         mock_service = MockSelectionService()
-        main_window.selection_service = mock_service
+        setattr(main_window, "selection_service", mock_service)
 
         # Reconnect signals with the mock service
         main_window._connect_status_signals()
@@ -309,7 +309,7 @@ class TestSelectionServiceIntegration:
         # Create a mock without the signal
         mock_service = Mock(spec=[])  # Empty spec, no selection_changed
 
-        main_window.selection_service = mock_service
+        setattr(main_window, "selection_service", mock_service)
 
         # Should not raise exception
         main_window._connect_status_signals()

--- a/tests/unit/presentation/test_panel_reset.py
+++ b/tests/unit/presentation/test_panel_reset.py
@@ -692,5 +692,5 @@ class TestStateAfterReset:
 
         # State manager should reflect the new state (all visible)
         assert main_window.panel_state_manager.state.panels["Hierarchy"].visible
-        assert main_window.panel_state_manager.state.panels["Properties"].visible
+        assert main_window.panel_state_manager.state.panels["Properties"].visible  # type: ignore[unreachable]
         assert main_window.panel_state_manager.state.panels["Messages"].visible

--- a/tests/unit/presentation/test_toolbar_file_edit_search.py
+++ b/tests/unit/presentation/test_toolbar_file_edit_search.py
@@ -231,7 +231,7 @@ class TestFileActions:
         Acceptance Criteria:
             - File dialog filters for `.ckt` and `.cdl` files
         """
-        captured_filter = None
+        captured_filter: str | None = None
 
         def mock_get_open_filename(
             *args: object, **kwargs: object
@@ -239,9 +239,9 @@ class TestFileActions:
             nonlocal captured_filter
             # Qt's filter string is typically the 4th positional arg or 'filter' kwarg
             if len(args) >= 4:
-                captured_filter = args[3]
+                captured_filter = str(args[3])
             elif "filter" in kwargs:
-                captured_filter = kwargs["filter"]
+                captured_filter = str(kwargs["filter"])
             return ("", "")
 
         monkeypatch.setattr(QFileDialog, "getOpenFileName", mock_get_open_filename)
@@ -380,7 +380,7 @@ class TestUndoRedoStateManagement:
         Acceptance Criteria:
             - Undo button enables after first expansion/collapse
         """
-        main_window._expansion_service = mock_expansion_service
+        setattr(main_window, "_expansion_service", mock_expansion_service)
         mock_expansion_service.can_undo.return_value = True
         mock_expansion_service.can_redo.return_value = False
 
@@ -397,7 +397,7 @@ class TestUndoRedoStateManagement:
         Acceptance Criteria:
             - Redo button enables after undo
         """
-        main_window._expansion_service = mock_expansion_service
+        setattr(main_window, "_expansion_service", mock_expansion_service)
         mock_expansion_service.can_undo.return_value = False
         mock_expansion_service.can_redo.return_value = True
 
@@ -415,7 +415,7 @@ class TestUndoRedoStateManagement:
             - Undo button disables when history empty
             - Redo button disables when no redo available
         """
-        main_window._expansion_service = mock_expansion_service
+        setattr(main_window, "_expansion_service", mock_expansion_service)
         mock_expansion_service.can_undo.return_value = False
         mock_expansion_service.can_redo.return_value = False
 
@@ -428,7 +428,7 @@ class TestUndoRedoStateManagement:
         self, main_window: InkMainWindow, mock_expansion_service: Mock
     ) -> None:
         """Test both buttons enabled when both undo and redo available."""
-        main_window._expansion_service = mock_expansion_service
+        setattr(main_window, "_expansion_service", mock_expansion_service)
         mock_expansion_service.can_undo.return_value = True
         mock_expansion_service.can_redo.return_value = True
 
@@ -445,7 +445,7 @@ class TestUndoRedoStateManagement:
         Acceptance Criteria:
             - Clicking Undo button undoes last expansion/collapse
         """
-        main_window._expansion_service = mock_expansion_service
+        setattr(main_window, "_expansion_service", mock_expansion_service)
         mock_expansion_service.can_undo.return_value = True
         main_window._undo_action.setEnabled(True)
 
@@ -461,7 +461,7 @@ class TestUndoRedoStateManagement:
         Acceptance Criteria:
             - Clicking Redo button redoes last undone action
         """
-        main_window._expansion_service = mock_expansion_service
+        setattr(main_window, "_expansion_service", mock_expansion_service)
         mock_expansion_service.can_redo.return_value = True
         main_window._redo_action.setEnabled(True)
 
@@ -473,7 +473,7 @@ class TestUndoRedoStateManagement:
         self, main_window: InkMainWindow, mock_expansion_service: Mock
     ) -> None:
         """Test undo/redo state updates after undo operation."""
-        main_window._expansion_service = mock_expansion_service
+        setattr(main_window, "_expansion_service", mock_expansion_service)
         mock_expansion_service.can_undo.return_value = True
         mock_expansion_service.can_redo.return_value = False
         main_window._undo_action.setEnabled(True)
@@ -564,7 +564,7 @@ class TestSearchPanelIntegration:
         Acceptance Criteria:
             - Clicking Search button shows search panel
         """
-        main_window._search_panel = mock_search_panel
+        setattr(main_window, "_search_panel", mock_search_panel)
         mock_search_panel.isVisible.return_value = False
 
         main_window._on_find()
@@ -580,7 +580,7 @@ class TestSearchPanelIntegration:
         Acceptance Criteria:
             - Clicking Search button focuses search input if panel already visible
         """
-        main_window._search_panel = mock_search_panel
+        setattr(main_window, "_search_panel", mock_search_panel)
         mock_search_panel.isVisible.return_value = True
 
         main_window._on_find()

--- a/tests/unit/presentation/test_view_help_menus.py
+++ b/tests/unit/presentation/test_view_help_menus.py
@@ -698,6 +698,7 @@ class TestHelpMenuAboutDialog:
 
         # Mock QMessageBox.about to prevent blocking
         with patch("ink.presentation.main_window.QMessageBox.about") as mock_about:
+            assert about_action is not None
             about_action.trigger()
 
             mock_about.assert_called_once()
@@ -723,6 +724,7 @@ class TestHelpMenuAboutDialog:
                 break
 
         with patch("ink.presentation.main_window.QMessageBox.about") as mock_about:
+            assert about_action is not None
             about_action.trigger()
 
             args = mock_about.call_args[0]
@@ -747,6 +749,7 @@ class TestHelpMenuAboutDialog:
                 break
 
         with patch("ink.presentation.main_window.QMessageBox.about") as mock_about:
+            assert about_action is not None
             about_action.trigger()
 
             args = mock_about.call_args[0]
@@ -771,6 +774,7 @@ class TestHelpMenuAboutDialog:
                 break
 
         with patch("ink.presentation.main_window.QMessageBox.about") as mock_about:
+            assert about_action is not None
             about_action.trigger()
 
             args = mock_about.call_args[0]
@@ -796,6 +800,7 @@ class TestHelpMenuAboutDialog:
                 break
 
         with patch("ink.presentation.main_window.QMessageBox.about") as mock_about:
+            assert about_action is not None
             about_action.trigger()
 
             args = mock_about.call_args[0]

--- a/tests/unit/presentation/utils/test_icon_provider.py
+++ b/tests/unit/presentation/utils/test_icon_provider.py
@@ -206,7 +206,7 @@ class TestResourceFilesExist:
         for resource_path in IconProvider.ICON_MAP.values():
             qfile = QFile(resource_path)
             if qfile.open(QFile.OpenModeFlag.ReadOnly):
-                content = bytes(qfile.readAll()).decode("utf-8")
+                content = bytes(qfile.readAll().data()).decode("utf-8")
                 qfile.close()
                 # Basic SVG validation - should contain svg tag
                 assert "<svg" in content.lower(), (


### PR DESCRIPTION
## Summary
- Implement `PinItem` class for rendering pins on cell symbols in the Qt Graphics Scene
- Fix 110 mypy type errors across test files for strict type checking compliance
- Add comprehensive TDD tests (39 test cases) for `PinItem` functionality
- Add `verify` npm script for combined type checking and test execution

## Technical Details

### New Implementation
- `src/ink/presentation/canvas/pin_item.py`: Custom `QGraphicsItem` subclass for pin rendering
  - `boundingRect()`: Returns appropriate rect based on detail level
  - `paint()`: Renders pin circle, direction arrow, and name label based on `DetailLevel`
  - `get_connection_point()`: Returns scene coordinates using `mapToScene()` for net routing
  - `set_detail_level()`: Controls visibility (MINIMAL/BASIC/FULL)
  - Constants: `PIN_RADIUS=3.0`, `ARROW_SIZE=8.0`, `LABEL_OFFSET=5.0`

### Test Type Hint Fixes
- Added `TYPE_CHECKING` imports for `QtBot`, `InkMainWindow`, and other test types
- Added `assert ... is not None` guards for `findChild()` returns (`QToolBar`, `QAction`)
- Used `setattr()` for dynamic attribute access in test mocks (`_expansion_service`, `selection_service`)
- Added correct `# type: ignore[error-code]` for intentional type violations
- Fixed `QByteArray.data()` conversion to bytes in `test_icon_provider.py`

### Files Modified
- `package.json`: Added `verify` script
- 17 test files: Type hint fixes for mypy compliance
- 3 spec files: Post-docs and implementation narrative

## Testing
```bash
uv run mypy  # Success: no issues found in 166 source files
uv run pytest tests/  # 1838 passed, 1 skipped
npm run verify  # Combined type check and test run
```

## Breaking Changes
- None